### PR TITLE
FEATURE: Adde poetry.lock parser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ You can use one of the parsers to obtain information about your project or envir
 | Parser | Class / Import | Description |
 | ------- | ------ | ------ |
 | Environment | `from cyclonedx.parser.environment import EnvironmentParser` | Looks at the packaged installed in your current Python environment. |
+| PoetryParser | `from cyclonedx.parser.poetry import PoetryParser` | Parses `poetry.lock` content passed in as a string. |
+| PoetryFileParser | `from cyclonedx.parser.poetry import PoetryFileParser` | Parses the `poetry.lock` file at the supplied path. |
 | RequirementsParser | `from cyclonedx.parser.requirements import RequirementsParser` | Parses a multiline string that you provide that conforms to the `requirements.txt` [PEP-508](https://www.python.org/dev/peps/pep-0508/) standard. |
 | RequirementsFileParser | `from cyclonedx.parser.requirements import RequirementsFileParser` | Parses a file that you provide the path to that conforms to the `requirements.txt` [PEP-508](https://www.python.org/dev/peps/pep-0508/) standard. |
 

--- a/cyclonedx/parser/__init__.py
+++ b/cyclonedx/parser/__init__.py
@@ -23,6 +23,9 @@ from ..model.component import Component
 class BaseParser(ABC):
     _components: List[Component] = []
 
+    def __init__(self):
+        self._components.clear()
+
     def component_count(self) -> int:
         return len(self._components)
 

--- a/cyclonedx/parser/environment.py
+++ b/cyclonedx/parser/environment.py
@@ -37,6 +37,8 @@ class EnvironmentParser(BaseParser):
     """
 
     def __init__(self):
+        super().__init__()
+
         import pkg_resources
 
         i: pkg_resources.DistInfoDistribution

--- a/cyclonedx/parser/poetry.py
+++ b/cyclonedx/parser/poetry.py
@@ -1,0 +1,44 @@
+# encoding: utf-8
+
+# This file is part of CycloneDX Python Lib
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+import toml
+
+from . import BaseParser
+from ..model.component import Component
+
+
+class PoetryParser(BaseParser):
+
+    def __init__(self, poetry_lock_contents: str):
+        super().__init__()
+        print("Starting Poetry Parser {}".format(len(self.get_components())))
+        poetry_lock = toml.loads(poetry_lock_contents)
+
+        for package in poetry_lock['package']:
+            self._components.append(Component(
+                name=package['name'], version=package['version'],
+            ))
+
+
+class PoetryFileParser(PoetryParser):
+
+    def __init__(self, poetry_lock_filename: str):
+        with open(poetry_lock_filename) as r:
+            super(PoetryFileParser, self).__init__(poetry_lock_contents=r.read())
+        r.close()

--- a/cyclonedx/parser/requirements.py
+++ b/cyclonedx/parser/requirements.py
@@ -26,6 +26,8 @@ from ..model.component import Component
 class RequirementsParser(BaseParser):
 
     def __init__(self, requirements_content: str):
+        super().__init__()
+
         requirements = pkg_resources.parse_requirements(requirements_content)
         for requirement in requirements:
             """

--- a/poetry.lock
+++ b/poetry.lock
@@ -200,7 +200,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -271,7 +271,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "872a02e9b948411d7c3c0f0a0dffd06c6e2b0d4504d1cda65cee74c095debbbc"
+content-hash = "46b319eda845ba184c8ee63869ad8919ad0f219e87ce3bb9b71f7d743cbd504c"
 
 [metadata.files]
 "backports.entry-points-selectable" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ packageurl-python = "^0.9.4"
 requirements_parser = "^0.2.0"
 setuptools = "^50.3.2"
 importlib-metadata = "^4.8.1"
+toml = "^0.10.2"
 
 [tool.poetry.dev-dependencies]
 tox = "^3.24.3"

--- a/tests/fixtures/poetry-lock-simple.txt
+++ b/tests/fixtures/poetry-lock-simple.txt
@@ -1,0 +1,18 @@
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "main"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.9"
+content-hash = "3dc7af43729f7ff1e7cf84103a3e2c1945f233884eaa149c7e8d92cccb593984"
+
+[metadata.files]
+toml = [
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
+]

--- a/tests/test_parser_poetry.py
+++ b/tests/test_parser_poetry.py
@@ -1,0 +1,36 @@
+# encoding: utf-8
+
+# This file is part of CycloneDX Python Lib
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+import os
+from unittest import TestCase
+
+from cyclonedx.parser.poetry import PoetryFileParser
+
+
+class TestPoetryParser(TestCase):
+
+    def test_simple(self):
+        tests_poetry_lock_file = os.path.join(os.path.dirname(__file__), 'fixtures/poetry-lock-simple.txt')
+
+        parser = PoetryFileParser(poetry_lock_filename=tests_poetry_lock_file)
+        self.assertEqual(1, parser.component_count())
+        components = parser.get_components()
+        print(components)
+        self.assertEqual('toml', components[0].get_name())
+        self.assertEqual('0.10.2', components[0].get_version())


### PR DESCRIPTION
We already support gleaning packages:
1. Installed in your current Python environment
2. Parsing of `requirements.txt` formatted files

This PR adds parsing support for `poetry.lock` files + some fixes discovered enroute.