### PR TITLE
fix: improved handling for `requirements.txt` content without pinned …

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ from cyclonedx.parser.environment import EnvironmentParser
 parser = EnvironmentParser()
 ```
 
+#### Notes on Requirements parsing
+
+CycloneDX software bill-of-materials require pinned versions of requirements. If your `requirements.txt` does not have 
+pinned versions, warnings will be recorded and the dependencies without pinned versions will be excluded from the 
+generated CycloneDX. CycloneDX schemas (from version 1.0+) require a component to have a version when included in a
+CycloneDX bill of materials (according to schema).
+
+If you need to use a `requirements.txt` in your project that does not have pinned versions an acceptable workaround 
+might be to:
+
+```
+pip install -r requirements.txt
+pip freeze > requirements-frozen.txt
+```
+
+You can then feed in the frozen requirements from `requirements-frozen.txt` _or_ use the `Environment` parser one you
+have `pip install`ed your dependencies.
+
 ### Modelling
 
 You can create a BOM Model from either a Parser instance or manually using the methods avaialbel directly on the `Bom` class.

--- a/cyclonedx/parser/__init__.py
+++ b/cyclonedx/parser/__init__.py
@@ -20,14 +20,40 @@ from typing import List
 from ..model.component import Component
 
 
+class ParserWarning:
+    _item: str
+    _warning: str
+
+    def __init__(self, item: str, warning: str):
+        self._item = item
+        self._warning = warning
+
+    def get_item(self) -> str:
+        return self._item
+
+    def get_warning_message(self) -> str:
+        return self._warning
+
+    def __repr__(self):
+        return '<ParserWarning item=\'{}\'>'.format(self._item)
+
+
 class BaseParser(ABC):
     _components: List[Component] = []
+    _warnings: List[ParserWarning] = []
 
     def __init__(self):
         self._components.clear()
+        self._warnings.clear()
 
     def component_count(self) -> int:
         return len(self._components)
 
     def get_components(self) -> List[Component]:
         return self._components
+
+    def get_warnings(self) -> List[ParserWarning]:
+        return self._warnings
+
+    def has_warnings(self) -> bool:
+        return len(self._warnings) > 0

--- a/cyclonedx/parser/requirements.py
+++ b/cyclonedx/parser/requirements.py
@@ -19,7 +19,7 @@
 
 import pkg_resources
 
-from . import BaseParser
+from . import BaseParser, ParserWarning
 from ..model.component import Component
 
 
@@ -35,13 +35,22 @@ class RequirementsParser(BaseParser):
             Note that the below line will get the first (lowest) version specified in the Requirement and
             ignore the operator (it might not be ==). This is passed to the Component.
 
-            For example if a requirement was listed as: "PickyThing>1.6,<=1.9,!=1.8.6", we'll be interpretting this
+            For example if a requirement was listed as: "PickyThing>1.6,<=1.9,!=1.8.6", we'll be interpreting this
             as if it were written "PickyThing==1.6"
             """
-            (op, version) = requirement.specs[0]
-            self._components.append(Component(
-                name=requirement.project_name, version=version
-            ))
+            try:
+                (op, version) = requirement.specs[0]
+                self._components.append(Component(
+                    name=requirement.project_name, version=version
+                ))
+            except IndexError:
+                self._warnings.append(
+                    ParserWarning(
+                        item=requirement.project_name,
+                        warning='Requirement \'{}\' does not have a pinned version and cannot be included in your '
+                                'CycloneDX SBOM.'.format(requirement.project_name)
+                    )
+                )
 
 
 class RequirementsFileParser(RequirementsParser):

--- a/tests/fixtures/requirements-without-pinned-versions.txt
+++ b/tests/fixtures/requirements-without-pinned-versions.txt
@@ -1,0 +1,5 @@
+certifi==2021.5.30 # via requests
+chardet>=4.0.0 # via requests
+idna
+requests
+urllib3

--- a/tests/test_parser_requirements.py
+++ b/tests/test_parser_requirements.py
@@ -33,6 +33,7 @@ class TestRequirementsParser(TestCase):
             )
             r.close()
         self.assertTrue(1, parser.component_count())
+        self.assertFalse(parser.has_warnings())
 
     def test_example_1(self):
         with open(os.path.join(os.path.dirname(__file__), 'fixtures/requirements-example-1.txt')) as r:
@@ -41,6 +42,7 @@ class TestRequirementsParser(TestCase):
             )
             r.close()
         self.assertTrue(3, parser.component_count())
+        self.assertFalse(parser.has_warnings())
 
     def test_example_with_comments(self):
         with open(os.path.join(os.path.dirname(__file__), 'fixtures/requirements-with-comments.txt')) as r:
@@ -49,6 +51,7 @@ class TestRequirementsParser(TestCase):
             )
             r.close()
         self.assertTrue(5, parser.component_count())
+        self.assertFalse(parser.has_warnings())
 
     def test_example_multiline_with_comments(self):
         with open(os.path.join(os.path.dirname(__file__), 'fixtures/requirements-multilines-with-comments.txt')) as r:
@@ -57,6 +60,7 @@ class TestRequirementsParser(TestCase):
             )
             r.close()
         self.assertTrue(5, parser.component_count())
+        self.assertFalse(parser.has_warnings())
 
     @unittest.skip('Not yet supported')
     def test_example_with_hashes(self):
@@ -66,3 +70,14 @@ class TestRequirementsParser(TestCase):
             )
             r.close()
         self.assertTrue(5, parser.component_count())
+        self.assertFalse(parser.has_warnings())
+
+    def test_example_without_pinned_versions(self):
+        with open(os.path.join(os.path.dirname(__file__), 'fixtures/requirements-without-pinned-versions.txt')) as r:
+            parser = RequirementsParser(
+                requirements_content=r.read()
+            )
+            r.close()
+        self.assertTrue(2, parser.component_count())
+        self.assertTrue(parser.has_warnings())
+        self.assertEqual(3, len(parser.get_warnings()))


### PR DESCRIPTION
This PR addresses poor behaviour when supplying a `requirements.txt` content that includes one or more dependencies that are defined without a version statement.

Previously an `IndexError` would have been thrown and stopped execution.

This PR introduces capabilities for handling these, skipping them from being added to the BOM but also provided a mechanism for supplying warnings back to the invoker so that they can be aware their generated BOM is not a complete representation.

Signed-off-by: Paul Horton <phorton@sonatype.com>