### PR TITLE
Support for representing File as Component

### DIFF
--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -15,6 +15,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import hashlib
 from enum import Enum
 
 """
@@ -23,6 +24,16 @@ Uniform set of models to represent objects within a CycloneDX software bill-of-m
 You can either create a `cyclonedx.model.bom.Bom` yourself programmatically, or generate a `cyclonedx.model.bom.Bom`
 from a `cyclonedx.parser.BaseParser` implementation.
 """
+
+
+def sha1sum(filename: str) -> str:
+    h = hashlib.sha1()
+    b = bytearray(128 * 1024)
+    mv = memoryview(b)
+    with open(filename, 'rb', buffering=0) as f:
+        for n in iter(lambda: f.readinto(mv), 0):
+            h.update(mv[:n])
+    return h.hexdigest()
 
 
 class HashAlgorithm(Enum):

--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -53,6 +53,15 @@ class Json(BaseOutput, BaseSchemaVersion):
             "purl": component.get_purl()
         }
 
+        if len(component.get_hashes()) > 0:
+            hashes = []
+            for component_hash in component.get_hashes():
+                hashes.append({
+                    "alg": component_hash.get_algorithm().value,
+                    "content": component_hash.get_hash_value()
+                })
+            c['hashes'] = hashes
+
         if self.component_supports_author() and component.get_author() is not None:
             c['author'] = component.get_author()
 
@@ -67,11 +76,22 @@ class Json(BaseOutput, BaseSchemaVersion):
         if self.bom_metadata_supports_tools() and len(bom_metadata.get_tools()) > 0:
             metadata['tools'] = []
             for tool in bom_metadata.get_tools():
-                metadata['tools'].append({
+                tool_dict = {
                     "vendor": tool.get_vendor(),
                     "name": tool.get_name(),
                     "version": tool.get_version()
-                })
+                }
+
+                if len(tool.get_hashes()) > 0:
+                    hashes = []
+                    for tool_hash in tool.get_hashes():
+                        hashes.append({
+                            "alg": tool_hash.get_algorithm().value,
+                            "content": tool_hash.get_hash_value()
+                        })
+                    tool_dict['hashes'] = hashes
+
+                metadata['tools'].append(tool_dict)
 
         return metadata
 

--- a/cyclonedx/output/xml.py
+++ b/cyclonedx/output/xml.py
@@ -83,35 +83,22 @@ class Xml(BaseOutput, BaseSchemaVersion):
         if self.component_supports_author() and component.get_author() is not None:
             ElementTree.SubElement(component_element, 'author').text = component.get_author()
 
-        # if publisher and publisher != "UNKNOWN":
-        #     ElementTree.SubElement(component, "publisher").text = re.sub(RE_XML_ILLEGAL, "?", publisher)
-
-        # if name and name != "UNKNOWN":
+        # name
         ElementTree.SubElement(component_element, 'name').text = component.get_name()
 
-        # if version and version != "UNKNOWN":
+        # version
         ElementTree.SubElement(component_element, 'version').text = component.get_version()
 
-        # if description and description != "UNKNOWN":
-        #     ElementTree.SubElement(component, "description").text = re.sub(RE_XML_ILLEGAL, "?", description)
-        #
-        # if hashes:
-        #     hashes_elm = ElementTree.SubElement(component, "hashes")
-        #     for h in hashes:
-        #         ElementTree.SubElement(hashes_elm, "hash", alg=h.alg).text = h.content
-        #
-        # if len(licenses):
-        #     licenses_elm = ElementTree.SubElement(component, "licenses")
-        #     for component_license in licenses:
-        #         if component_license.license is not None:
-        #             license_elm = ElementTree.SubElement(licenses_elm, "license")
-        #             ElementTree.SubElement(license_elm, "name").text = re.sub(RE_XML_ILLEGAL, "?",
-        #             component_license.license.name)
-
-        # if purl:
+        # purl
         ElementTree.SubElement(component_element, 'purl').text = component.get_purl()
 
-        # ElementTree.SubElement(component, "modified").text = modified if modified else "false"
+        # hashes
+        if len(component.get_hashes()) > 0:
+            hashes_e = ElementTree.SubElement(component_element, 'hashes')
+            for hash in component.get_hashes():
+                ElementTree.SubElement(
+                    hashes_e, 'hash', {'alg': hash.get_algorithm().value}
+                ).text = hash.get_hash_value()
 
         return component_element
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -17,6 +17,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 
+from os.path import dirname, join
 from unittest import TestCase
 
 from packageurl import PackageURL
@@ -104,3 +105,14 @@ class TestComponent(TestCase):
             type='generic', name='/test.py', version='UNKNOWN'
         )
         self.assertEqual(TestComponent._component_generic_file.to_package_url(), purl)
+
+    def test_from_file_with_path_for_bom(self):
+        test_file = join(dirname(__file__), 'fixtures/bom_v1.3_setuptools.xml')
+        c = Component.for_file(absolute_file_path=test_file, path_for_bom='fixtures/bom_v1.3_setuptools.xml')
+        self.assertEqual(c.get_name(), 'fixtures/bom_v1.3_setuptools.xml')
+        self.assertEqual(c.get_version(), '0.0.0-16932e52ed1e')
+        purl = PackageURL(
+            type='generic', name='fixtures/bom_v1.3_setuptools.xml', version='0.0.0-16932e52ed1e'
+        )
+        self.assertEqual(c.to_package_url(), purl)
+        self.assertEqual(len(c.get_hashes()), 1)


### PR DESCRIPTION
Work conducted as part of looking to add CycloneDX output support to [Checkov](https://www.checkov.io/).

- Versioning of Files as per https://github.com/CycloneDX/cyclonedx.org/issues/34
- Helper methods to create Component from a file (local)
- Support to output hashes for Components in both XML and JSON

Other items:
- Added missing tool hashes in JSON output