### PR TITLE
add test for parse test for _libgcc_mutex conda package

### DIFF
--- a/tests/test_utils_conda.py
+++ b/tests/test_utils_conda.py
@@ -107,3 +107,20 @@ class TestUtilsConda(TestCase):
         self.assertEqual(cp['platform'], 'noarch')
         self.assertEqual(cp['version'], '2.10')
         self.assertEqual(cp['md5_hash'], '153ff132f593ea80aae2eea61a629c92')
+
+    def test_parse_conda_list_str_with_hash_4(self):
+        cp: CondaPackage = parse_conda_list_str_to_conda_package(
+            conda_list_str='https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2'
+                           '#d7c89558ba9fa0495403155b64376d81'
+        )
+
+        self.assertIsInstance(cp, dict)
+        self.assertEqual(cp['base_url'], 'https://conda.anaconda.org/conda-forge')
+        self.assertEqual(cp['build_number'], 0)
+        self.assertEqual(cp['build_string'], 'conda_forge')
+        self.assertEqual(cp['channel'], 'conda-forge')
+        self.assertEqual(cp['dist_name'], '_libgcc_mutex-0.1-conda_forge')
+        self.assertEqual(cp['name'], '_libgcc_mutex')
+        self.assertEqual(cp['platform'], 'linux-64')
+        self.assertEqual(cp['version'], '0.1')
+        self.assertEqual(cp['md5_hash'], 'd7c89558ba9fa0495403155b64376d81')


### PR DESCRIPTION
Thanks for this tool!

While working on using this after getting it to install in a relaxed environment (as described in #44), I'm seeing the following issues with some non-`anaconda.com` packages:

https://github.com/conda-forge/jake-feedstock/pull/3#issuecomment-955611284

(reproduced below)

Haven't had a chance to dig into exactly what is going wrong, but though that a failing test might demonstrate what I'm seeing, after a brief scan of `parse_conda_list_str_to_conda_package`.

---

This is up to building locally, but trying a self-test with

```bash
conda list --explicit | jake sbom -t CONDA
```

yielded:


```py
Put your Python dependencies in a chokehold

  File "$PREFIX/lib/python3.9/site-packages/jake/app.py", line 65, in execute
    exit_code: int = command.execute(arguments=self._arguments)
  File "$PREFIX/lib/python3.9/site-packages/jake/command/__init__.py", line 33, in execute
    self.handle_args()
  File "$PREFIX/lib/python3.9/site-packages/jake/command/sbom.py", line 37, in handle_args
    bom = Bom.from_parser(self._get_parser())
  File "$PREFIX/lib/python3.9/site-packages/jake/command/sbom.py", line 104, in _get_parser
    return CondaListExplicitParser(conda_data=input_data)
  File "$PREFIX/lib/python3.9/site-packages/cyclonedx/parser/conda.py", line 37, in __init__
    self._parse_to_conda_packages(data_str=conda_data)
  File "$PREFIX/lib/python3.9/site-packages/cyclonedx/parser/conda.py", line 95, in _parse_to_conda_packages
    conda_package = parse_conda_list_str_to_conda_package(conda_list_str=line)
  File "$PREFIX/lib/python3.9/site-packages/cyclonedx/utils/conda.py", line 105, in parse_conda_list_str_to_conda_package
    build_number = int(bnbs_parts.pop())
ValueError: invalid literal for int() with base 10: 'forge'
Tests failed for jake-1.1.0-py_0.tar.bz2 - moving package to /opt/conda/conda-bld/broken
WARNING:conda_build.build:Tests failed for jake-1.1.0-py_0.tar.bz2 - moving package to /opt/conda/conda-bld/broken
WARNING conda_build.build:tests_failed(2955): Tests failed for jake-1.1.0-py_0.tar.bz2 - moving package to /opt/conda/conda-bld/broken
TESTS FAILED: jake-1.1.0-py_0.tar.bz2
```

I'm wagering this is due to:

```
https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
```