### PR TITLE
model/vulnerability: fix optional type

### DIFF
--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -215,9 +215,11 @@ class Vulnerability:
     Represents <xs:complexType name="vulnerability">
     """
 
-    def __init__(self, id: str, source_name: Optional[str], source_url: Optional[str],
-                 ratings: Optional[List[VulnerabilityRating]], cwes: Optional[List[int]], description: Optional[str],
-                 recommendations: Optional[List[str]], advisories: Optional[List[str]]) -> None:
+    def __init__(self, id: str, source_name: Optional[str] = None, source_url: Optional[str] = None,
+                 ratings: Optional[List[VulnerabilityRating]] = None,
+                 cwes: Optional[List[int]] = None, description: Optional[str] = None,
+                 recommendations: Optional[List[str]] = None,
+                 advisories: Optional[List[str]] = None) -> None:
         self._id = id
         self._source_name = source_name
         self._source_url: Optional[ParseResult] = urlparse(source_url) if source_url else None


### PR DESCRIPTION
This fixes a small bug when constructing a `Vulnerability` model that eventually gets serialized to XML: `get_ratings` expects `self._ratings` to be a `List[VulnerabilityRating]` instead of an `Optional[...]`, so we default-initialize it if the constructor is passed `None`.

There are other type errors in the same constructor; I'll update this PR as I continue to try to get XML serialization working in `pip-audit`.

Downstream: https://github.com/trailofbits/pip-audit/pull/109