### PR TITLE
FIX: update Conda package parsing to handle `build` containing underscore

### DIFF
--- a/cyclonedx/utils/conda.py
+++ b/cyclonedx/utils/conda.py
@@ -96,13 +96,20 @@ def parse_conda_list_str_to_conda_package(conda_list_str: str) -> Optional[Conda
             pos = build_number_with_opt_string.find('.')
             build_number_with_opt_string = build_number_with_opt_string[0:pos]
 
+        build_string: str
+        build_number: Optional[int]
+
         if '_' in build_number_with_opt_string:
             bnbs_parts = build_number_with_opt_string.split('_')
-            if len(bnbs_parts) == 2:
-                build_number = int(bnbs_parts.pop())
+            # Build number will be the last part - check if it's an integer
+            # Updated logic given https://github.com/CycloneDX/cyclonedx-python-lib/issues/65
+            candidate_build_number: str = bnbs_parts.pop()
+            if candidate_build_number.isdigit():
+                build_number = int(candidate_build_number)
                 build_string = build_number_with_opt_string
             else:
-                raise ValueError(f'Unexpected build version string for Conda Package: {conda_list_str}')
+                build_number = None
+                build_string = build_number_with_opt_string
         else:
             build_string = ''
             build_number = int(build_number_with_opt_string)

--- a/cyclonedx/utils/conda.py
+++ b/cyclonedx/utils/conda.py
@@ -34,7 +34,7 @@ class CondaPackage(TypedDict):
     Internal package for unifying Conda package definitions to.
     """
     base_url: str
-    build_number: int
+    build_number: Optional[int]
     build_string: str
     channel: str
     dist_name: str

--- a/tests/test_utils_conda.py
+++ b/tests/test_utils_conda.py
@@ -108,7 +108,7 @@ class TestUtilsConda(TestCase):
         self.assertEqual(cp['version'], '2.10')
         self.assertEqual(cp['md5_hash'], '153ff132f593ea80aae2eea61a629c92')
 
-    def test_parse_conda_list_str_with_hash_4(self):
+    def test_parse_conda_list_str_with_hash_4(self) -> None:
         cp: CondaPackage = parse_conda_list_str_to_conda_package(
             conda_list_str='https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2'
                            '#d7c89558ba9fa0495403155b64376d81'

--- a/tests/test_utils_conda.py
+++ b/tests/test_utils_conda.py
@@ -107,3 +107,20 @@ class TestUtilsConda(TestCase):
         self.assertEqual(cp['platform'], 'noarch')
         self.assertEqual(cp['version'], '2.10')
         self.assertEqual(cp['md5_hash'], '153ff132f593ea80aae2eea61a629c92')
+
+    def test_parse_conda_list_str_with_hash_4(self):
+        cp: CondaPackage = parse_conda_list_str_to_conda_package(
+            conda_list_str='https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2'
+                           '#d7c89558ba9fa0495403155b64376d81'
+        )
+
+        self.assertIsInstance(cp, dict)
+        self.assertEqual(cp['base_url'], 'https://conda.anaconda.org/conda-forge')
+        self.assertIsNone(cp['build_number'])
+        self.assertEqual(cp['build_string'], 'conda_forge')
+        self.assertEqual(cp['channel'], 'conda-forge')
+        self.assertEqual(cp['dist_name'], '_libgcc_mutex-0.1-conda_forge')
+        self.assertEqual(cp['name'], '_libgcc_mutex')
+        self.assertEqual(cp['platform'], 'linux-64')
+        self.assertEqual(cp['version'], '0.1')
+        self.assertEqual(cp['md5_hash'], 'd7c89558ba9fa0495403155b64376d81')


### PR DESCRIPTION
Hopefully, this is the solution to the issue raised in #44, #51 and refined into #65.

@bollwyvl kindly provided an example Conda package URL that was breaking our parsing. This PR aims to make our parsing more robust and cater for the example provided.

Signed-off-by: Paul Horton <phorton@sonatype.com>