### PR TITLE
fix: removed requirements-parser as dependency (temp) as not available for Python 3 as Wheel

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -307,14 +307,6 @@ python-versions = ">=3.6"
 diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-name = "requirements-parser"
-version = "0.2.0"
-description = "Parses Pip requirement files"
-category = "main"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -421,7 +413,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "dd655aeed145133510e97c33024ced1bf2d4257c526b46ea55f9d69442c15b9b"
+content-hash = "6bd8ad682393a798580e171a4c85bf7ce93dea3dcd02734de355b2f9f89c566b"
 
 [metadata.files]
 attrs = [
@@ -660,10 +652,6 @@ pyflakes = [
 pyparsing = [
     {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
     {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
-]
-requirements-parser = [
-    {file = "requirements-parser-0.2.0.tar.gz", hash = "sha256:5963ee895c2d05ae9f58d3fc641082fb38021618979d6a152b6b1398bd7d4ed4"},
-    {file = "requirements_parser-0.2.0-py2-none-any.whl", hash = "sha256:76650b4a9d98fc65edf008a7920c076bb2a76c08eaae230ce4cfc6f51ea6a773"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ keywords = [
 # ATTENTION: keep `requirements.lowest.txt` file in sync
 python = "^3.6"
 packageurl-python = ">= 0.9"
-requirements_parser = ">= 0.2"
 setuptools = ">= 47.0.0"
 importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
 toml = "^0.10.0"

--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -2,7 +2,6 @@
 # see pyptoject file for ranges
 
 packageurl-python == 0.9.0
-requirements_parser == 0.2.0
 setuptools == 47.0.0
 importlib-metadata == 3.4.0 # ; python_version < '3.8'
 toml == 0.10.0


### PR DESCRIPTION
Part of #97 

Signed-off-by: Paul Horton <phorton@sonatype.com>