### PR TITLE
Converting properties list to a string before it is input into `hash`.

### DIFF
--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -511,7 +511,8 @@ class Component:
     def __hash__(self) -> int:
         return hash((
             self.author, self.copyright, self.description, str(self.external_references), self.group,
-            str(self.hashes), str(self.licenses), self.mime_type, self.name, self.properties, self.publisher, self.purl,
+            str(self.hashes), str(self.licenses), self.mime_type, self.name, str(
+                self.properties), self.publisher, self.purl,
             self.release_notes, self.scope, self.supplier, self.type, self.version, self.cpe
         ))
 


### PR DESCRIPTION
Resolved isssue #153 .

Signed-off-by: Aaron Otis <otis1@llnl.gov>