### PR TITLE
style: sort imports

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,17 @@
+[settings]
+## read the docs: https://pycqa.github.io/isort/docs/configuration/options.html
+## keep in sync with flake8 config - in `tox.ini` file
+known_first_party = cyclonedx
+skip_gitignore = true
+skip_glob =
+    build/*,dist/*,__pycache__,.eggs,*.egg-info*,
+    *_cache,*.cache,
+    .git/*,.tox/*,.venv/*,venv/*
+    _OLD/*,_TEST/*,
+    docs/*
+combine_as_imports = true
+default_section = THIRDPARTY
+ensure_newline_before_comments = true
+include_trailing_comma = true
+line_length = 120
+multi_line_output = 3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,17 @@ poetry install
 ## Code style
 
 This project uses [PEP8] Style Guide for Python Code.  
-Get it applied via:
+This project loves sorted imports.  
+Get it all applied via:
 
 ```shell
+poetry run isort .
 poetry run autopep8 --in-place -r .
 ```
 
 ## Testing
+
+Run all tests in dedicated environments, via:
 
 ```shell
 poetry run tox

--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -14,6 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import hashlib
 import re
 import sys
@@ -22,8 +23,13 @@ from datetime import datetime
 from enum import Enum
 from typing import Iterable, Optional, Set
 
-from ..exception.model import InvalidLocaleTypeException, InvalidUriException, NoPropertiesProvidedException, \
-    MutuallyExclusivePropertiesException, UnknownHashTypeException
+from ..exception.model import (
+    InvalidLocaleTypeException,
+    InvalidUriException,
+    MutuallyExclusivePropertiesException,
+    NoPropertiesProvidedException,
+    UnknownHashTypeException,
+)
 
 """
 Uniform set of models to represent objects within a CycloneDX software bill-of-materials.

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -16,14 +16,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from datetime import datetime, timezone
 from typing import Iterable, Optional, Set
-from uuid import uuid4, UUID
+from uuid import UUID, uuid4
 
-from . import ExternalReference, OrganizationalContact, OrganizationalEntity, LicenseChoice, Property, ThisTool, Tool
+from ..parser import BaseParser
+from . import ExternalReference, LicenseChoice, OrganizationalContact, OrganizationalEntity, Property, ThisTool, Tool
 from .component import Component
 from .service import Service
-from ..parser import BaseParser
 
 
 class BomMetaData:

--- a/cyclonedx/model/bom_ref.py
+++ b/cyclonedx/model/bom_ref.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from typing import Optional
 from uuid import uuid4
 

--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import warnings
 from enum import Enum
 from os.path import exists
@@ -24,13 +25,24 @@ from typing import Iterable, Optional, Set
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL  # type: ignore
 
-from . import AttachedText, Copyright, ExternalReference, HashAlgorithm, HashType, IdentifiableAction, LicenseChoice, \
-    OrganizationalEntity, Property, sha1sum, XsUri
+from ..exception.model import NoPropertiesProvidedException
+from . import (
+    AttachedText,
+    Copyright,
+    ExternalReference,
+    HashAlgorithm,
+    HashType,
+    IdentifiableAction,
+    LicenseChoice,
+    OrganizationalEntity,
+    Property,
+    XsUri,
+    sha1sum,
+)
 from .bom_ref import BomRef
 from .issue import IssueType
 from .release_note import ReleaseNotes
 from .vulnerability import Vulnerability
-from ..exception.model import NoPropertiesProvidedException
 
 
 class Commit:

--- a/cyclonedx/model/issue.py
+++ b/cyclonedx/model/issue.py
@@ -14,11 +14,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from enum import Enum
 from typing import Iterable, Optional, Set
 
-from . import XsUri
 from ..exception.model import NoPropertiesProvidedException
+from . import XsUri
 
 
 class IssueClassification(Enum):

--- a/cyclonedx/model/release_note.py
+++ b/cyclonedx/model/release_note.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from datetime import datetime
 from typing import Iterable, Optional, Set
 

--- a/cyclonedx/model/service.py
+++ b/cyclonedx/model/service.py
@@ -14,9 +14,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from typing import Iterable, Optional, Set
 
-from . import ExternalReference, DataClassification, LicenseChoice, OrganizationalEntity, Property, XsUri
+from . import DataClassification, ExternalReference, LicenseChoice, OrganizationalEntity, Property, XsUri
 from .bom_ref import BomRef
 from .release_note import ReleaseNotes
 

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import re
 import warnings
 from datetime import datetime
@@ -23,11 +24,15 @@ from decimal import Decimal
 from enum import Enum
 from typing import Iterable, Optional, Set, Tuple, Union
 
+from ..exception.model import MutuallyExclusivePropertiesException, NoPropertiesProvidedException
 from . import OrganizationalContact, OrganizationalEntity, Tool, XsUri
 from .bom_ref import BomRef
-from .impact_analysis import ImpactAnalysisAffectedStatus, ImpactAnalysisJustification, ImpactAnalysisResponse, \
-    ImpactAnalysisState
-from ..exception.model import MutuallyExclusivePropertiesException, NoPropertiesProvidedException
+from .impact_analysis import (
+    ImpactAnalysisAffectedStatus,
+    ImpactAnalysisJustification,
+    ImpactAnalysisResponse,
+    ImpactAnalysisState,
+)
 
 """
 This set of classes represents the data that is possible about known Vulnerabilities.

--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -16,17 +16,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import json
 from abc import abstractmethod
-from typing import cast, Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, cast
 
-from . import BaseOutput, SchemaVersion
-from .schema import BaseSchemaVersion, SchemaVersion1Dot0, SchemaVersion1Dot1, SchemaVersion1Dot2, SchemaVersion1Dot3, \
-    SchemaVersion1Dot4
-from .serializer.json import CycloneDxJSONEncoder
 from ..exception.output import FormatNotSupportedException
 from ..model.bom import Bom
 from ..model.component import Component
+from . import BaseOutput, SchemaVersion
+from .schema import (
+    BaseSchemaVersion,
+    SchemaVersion1Dot0,
+    SchemaVersion1Dot1,
+    SchemaVersion1Dot2,
+    SchemaVersion1Dot3,
+    SchemaVersion1Dot4,
+)
+from .serializer.json import CycloneDxJSONEncoder
 
 ComponentDict = Dict[str, Union[
     str,

--- a/cyclonedx/output/serializer/json.py
+++ b/cyclonedx/output/serializer/json.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from datetime import datetime
 from decimal import Decimal
 from enum import Enum

--- a/cyclonedx/output/xml.py
+++ b/cyclonedx/output/xml.py
@@ -21,17 +21,32 @@ import warnings
 from typing import Optional, Set
 from xml.etree import ElementTree
 
-from . import BaseOutput, SchemaVersion
-from .schema import BaseSchemaVersion, SchemaVersion1Dot0, SchemaVersion1Dot1, SchemaVersion1Dot2, SchemaVersion1Dot3, \
-    SchemaVersion1Dot4
-from ..model import AttachedText, ExternalReference, HashType, IdentifiableAction, LicenseChoice, \
-    OrganizationalEntity, OrganizationalContact, Property, Tool
+from ..model import (
+    AttachedText,
+    ExternalReference,
+    HashType,
+    IdentifiableAction,
+    LicenseChoice,
+    OrganizationalContact,
+    OrganizationalEntity,
+    Property,
+    Tool,
+)
 from ..model.bom import Bom
 from ..model.bom_ref import BomRef
 from ..model.component import Component, Patch
 from ..model.release_note import ReleaseNotes
 from ..model.service import Service
-from ..model.vulnerability import Vulnerability, VulnerabilityRating, VulnerabilitySource, BomTargetVersionRange
+from ..model.vulnerability import BomTargetVersionRange, Vulnerability, VulnerabilityRating, VulnerabilitySource
+from . import BaseOutput, SchemaVersion
+from .schema import (
+    BaseSchemaVersion,
+    SchemaVersion1Dot0,
+    SchemaVersion1Dot1,
+    SchemaVersion1Dot2,
+    SchemaVersion1Dot3,
+    SchemaVersion1Dot4,
+)
 
 
 class Xml(BaseOutput, BaseSchemaVersion):

--- a/poetry.lock
+++ b/poetry.lock
@@ -105,6 +105,22 @@ flake8 = ">=3.0.0"
 dev = ["coverage", "hypothesis", "hypothesmith (>=0.2)", "pre-commit"]
 
 [[package]]
+name = "flake8-isort"
+version = "4.1.1"
+description = "flake8 plugin that integrates isort ."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flake8 = ">=3.2.1,<5"
+isort = ">=4.3.5,<6"
+testfixtures = ">=6.8.0,<7"
+
+[package.extras]
+test = ["pytest-cov"]
+
+[[package]]
 name = "importlib-metadata"
 version = "4.2.0"
 description = "Read metadata from Python packages"
@@ -134,6 +150,20 @@ zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jsonschema"
@@ -303,6 +333,19 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "testfixtures"
+version = "6.18.4"
+description = "A collection of helpers and mock objects for unit tests and doc tests."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.extras]
+build = ["setuptools-git", "wheel", "twine"]
+docs = ["sphinx", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+test = ["pytest (>=3.6)", "pytest-cov", "pytest-django", "zope.component", "sybil", "twisted", "mock", "django (<2)", "django"]
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -420,7 +463,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "6a766bb8018a3c7492f24fb8d7567298cd38cad8253ade1a579871066dcbdf60"
+content-hash = "792f56ebd3fdfaf01bbca06fc7f24873ef9e18d062b8df78da934be25fd34cc7"
 
 [metadata.files]
 attrs = [
@@ -504,6 +547,10 @@ flake8-bugbear = [
     {file = "flake8-bugbear-22.1.11.tar.gz", hash = "sha256:4c2a4136bd4ecb8bf02d5159af302ffc067642784c9d0488b33ce4610da825ee"},
     {file = "flake8_bugbear-22.1.11-py3-none-any.whl", hash = "sha256:ce7ae44aaaf67ef192b8a6de94a5ac617144e1675ad0654fdea556f48dc18d9b"},
 ]
+flake8-isort = [
+    {file = "flake8-isort-4.1.1.tar.gz", hash = "sha256:d814304ab70e6e58859bc5c3e221e2e6e71c958e7005239202fee19c24f82717"},
+    {file = "flake8_isort-4.1.1-py3-none-any.whl", hash = "sha256:c4e8b6dcb7be9b71a02e6e5d4196cefcef0f3447be51e82730fb336fff164949"},
+]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
     {file = "importlib_metadata-4.2.0.tar.gz", hash = "sha256:b7e52a1f8dec14a75ea73e0891f3060099ca1d8e6a462a4dff11c3e119ea1b31"},
@@ -511,6 +558,10 @@ importlib-metadata = [
 importlib-resources = [
     {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
     {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 jsonschema = [
     {file = "jsonschema-4.4.0-py3-none-any.whl", hash = "sha256:77281a1f71684953ee8b3d488371b162419767973789272434bbc3f29d9c8823"},
@@ -667,6 +718,10 @@ pyrsistent = [
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+testfixtures = [
+    {file = "testfixtures-6.18.4-py2.py3-none-any.whl", hash = "sha256:27cfa35006407ef31a4e8752873ca2232fd5761e29047a86c919e363e0e17196"},
+    {file = "testfixtures-6.18.4.tar.gz", hash = "sha256:878f617c411793f155c26b39330a095a1cc58844d88bcdc767a65c7fc2096b54"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,11 @@ tox = "^3.24.3"
 coverage = "^6.2"
 mypy = ">= 0.920, < 1.00"
 autopep8 = "^1.6.0"
+isort = { version = "^5.10.0", python = ">= 3.6.1" }
 flake8 = "^4.0.1"
 flake8-annotations = {version = "^2.7.0", python = ">= 3.6.2"}
 flake8-bugbear = "^22.1.11"
+flake8-isort = { version = "^4.1.0", python = ">= 3.6.1" }
 jsonschema = { version = ">= 4.4.0", python = "> 3.6"}
 lxml = ">=4.7.0"
 xmldiff = ">=2.4"

--- a/tests/base.py
+++ b/tests/base.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import io
 import json
 import os
@@ -34,7 +35,7 @@ from xmldiff.actions import MoveNode
 from cyclonedx.output import SchemaVersion
 
 if sys.version_info >= (3, 7):
-    from jsonschema import validate as json_validate, ValidationError
+    from jsonschema import ValidationError, validate as json_validate
 
 if sys.version_info >= (3, 8, 0):
     from importlib.metadata import version

--- a/tests/data.py
+++ b/tests/data.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import base64
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -23,19 +24,57 @@ from typing import List, Optional
 
 from packageurl import PackageURL
 
-from cyclonedx.model import AttachedText, DataClassification, DataFlow, Encoding, ExternalReference, \
-    ExternalReferenceType, HashType, LicenseChoice, License, Note, NoteText, OrganizationalContact, \
-    OrganizationalEntity, Property, Tool, XsUri
+from cyclonedx.model import (
+    AttachedText,
+    DataClassification,
+    DataFlow,
+    Encoding,
+    ExternalReference,
+    ExternalReferenceType,
+    HashType,
+    License,
+    LicenseChoice,
+    Note,
+    NoteText,
+    OrganizationalContact,
+    OrganizationalEntity,
+    Property,
+    Tool,
+    XsUri,
+)
 from cyclonedx.model.bom import Bom
-from cyclonedx.model.component import Commit, Component, ComponentEvidence, ComponentType, Copyright, Patch, \
-    PatchClassification, Pedigree, Swid, ComponentScope
+from cyclonedx.model.component import (
+    Commit,
+    Component,
+    ComponentEvidence,
+    ComponentScope,
+    ComponentType,
+    Copyright,
+    Patch,
+    PatchClassification,
+    Pedigree,
+    Swid,
+)
 from cyclonedx.model.issue import IssueClassification, IssueType, IssueTypeSource
 from cyclonedx.model.release_note import ReleaseNotes
 from cyclonedx.model.service import Service
-from cyclonedx.model.vulnerability import ImpactAnalysisState, ImpactAnalysisJustification, ImpactAnalysisResponse, \
-    ImpactAnalysisAffectedStatus, Vulnerability, VulnerabilityCredits, VulnerabilityRating, VulnerabilitySeverity, \
-    VulnerabilitySource, VulnerabilityScoreSource, VulnerabilityAdvisory, VulnerabilityReference, \
-    VulnerabilityAnalysis, BomTarget, BomTargetVersionRange
+from cyclonedx.model.vulnerability import (
+    BomTarget,
+    BomTargetVersionRange,
+    ImpactAnalysisAffectedStatus,
+    ImpactAnalysisJustification,
+    ImpactAnalysisResponse,
+    ImpactAnalysisState,
+    Vulnerability,
+    VulnerabilityAdvisory,
+    VulnerabilityAnalysis,
+    VulnerabilityCredits,
+    VulnerabilityRating,
+    VulnerabilityReference,
+    VulnerabilityScoreSource,
+    VulnerabilitySeverity,
+    VulnerabilitySource,
+)
 
 MOCK_TIMESTAMP: datetime = datetime(2021, 12, 31, 10, 0, 0, 0).replace(tzinfo=timezone.utc)
 MOCK_UUID_1 = 'be2c6502-7e9a-47db-9a66-e34f729810a3'

--- a/tests/test_bom.py
+++ b/tests/test_bom.py
@@ -16,11 +16,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from unittest import TestCase
+
+from data import get_bom_with_component_setuptools_with_vulnerability
 
 from cyclonedx.model.bom import Bom, ThisTool, Tool
 from cyclonedx.model.component import Component, ComponentType
-from data import get_bom_with_component_setuptools_with_vulnerability
 
 
 class TestBom(TestCase):

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from os.path import dirname, join
 from unittest import TestCase
 

--- a/tests/test_e2e_environment.py
+++ b/tests/test_e2e_environment.py
@@ -16,15 +16,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import json
+from unittest import TestCase
+
 import pkg_resources
 from lxml import etree
 from packageurl import PackageURL
-from unittest import TestCase
 
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
-from cyclonedx.output import get_instance, OutputFormat
+from cyclonedx.output import OutputFormat, get_instance
 from cyclonedx.output.json import Json
 from cyclonedx.output.xml import Xml
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -16,15 +16,30 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import base64
 import datetime
 from time import sleep
 from unittest import TestCase
 
-from cyclonedx.exception.model import InvalidLocaleTypeException, InvalidUriException, UnknownHashTypeException, \
-    NoPropertiesProvidedException
-from cyclonedx.model import Copyright, Encoding, ExternalReference, ExternalReferenceType, HashAlgorithm, HashType, \
-    IdentifiableAction, Note, NoteText, XsUri
+from cyclonedx.exception.model import (
+    InvalidLocaleTypeException,
+    InvalidUriException,
+    NoPropertiesProvidedException,
+    UnknownHashTypeException,
+)
+from cyclonedx.model import (
+    Copyright,
+    Encoding,
+    ExternalReference,
+    ExternalReferenceType,
+    HashAlgorithm,
+    HashType,
+    IdentifiableAction,
+    Note,
+    NoteText,
+    XsUri,
+)
 from cyclonedx.model.issue import IssueClassification, IssueType, IssueTypeSource
 
 

--- a/tests/test_model_component.py
+++ b/tests/test_model_component.py
@@ -16,18 +16,43 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import datetime
 from typing import List
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
+from data import (
+    get_component_setuptools_simple,
+    get_component_setuptools_simple_no_version,
+    get_component_toml_with_hashes_with_references,
+    get_issue_1,
+    get_issue_2,
+    get_pedigree_1,
+    get_swid_1,
+    get_swid_2,
+)
+
 from cyclonedx.exception.model import NoPropertiesProvidedException
-from cyclonedx.model import AttachedText, Copyright, ExternalReference, ExternalReferenceType, \
-    IdentifiableAction, Property, XsUri
-from cyclonedx.model.component import Commit, Component, ComponentEvidence, ComponentType, Diff, Patch, \
-    PatchClassification, Pedigree
-from data import get_component_setuptools_simple, get_component_setuptools_simple_no_version, \
-    get_component_toml_with_hashes_with_references, get_issue_1, get_issue_2, get_pedigree_1, get_swid_1, get_swid_2
+from cyclonedx.model import (
+    AttachedText,
+    Copyright,
+    ExternalReference,
+    ExternalReferenceType,
+    IdentifiableAction,
+    Property,
+    XsUri,
+)
+from cyclonedx.model.component import (
+    Commit,
+    Component,
+    ComponentEvidence,
+    ComponentType,
+    Diff,
+    Patch,
+    PatchClassification,
+    Pedigree,
+)
 
 
 class TestModelCommit(TestCase):

--- a/tests/test_model_issue.py
+++ b/tests/test_model_issue.py
@@ -16,13 +16,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from unittest import TestCase
+
+from data import get_issue_1, get_issue_2
 
 from cyclonedx.exception.model import NoPropertiesProvidedException
 from cyclonedx.model import XsUri
 from cyclonedx.model.issue import IssueTypeSource
-
-from data import get_issue_1, get_issue_2
 
 
 class TestModelIssueType(TestCase):

--- a/tests/test_model_release_note.py
+++ b/tests/test_model_release_note.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import datetime
 from unittest import TestCase
 

--- a/tests/test_model_service.py
+++ b/tests/test_model_service.py
@@ -16,6 +16,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from unittest import TestCase
 from unittest.mock import Mock, patch
 

--- a/tests/test_model_vulnerability.py
+++ b/tests/test_model_vulnerability.py
@@ -16,12 +16,17 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 import unittest
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from cyclonedx.model.vulnerability import Vulnerability, VulnerabilityRating, VulnerabilitySeverity, \
-    VulnerabilityScoreSource
+from cyclonedx.model.vulnerability import (
+    Vulnerability,
+    VulnerabilityRating,
+    VulnerabilityScoreSource,
+    VulnerabilitySeverity,
+)
 
 
 class TestModelVulnerability(TestCase):

--- a/tests/test_output_generic.py
+++ b/tests/test_output_generic.py
@@ -21,7 +21,7 @@ from unittest import TestCase
 
 from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
-from cyclonedx.output import get_instance, OutputFormat, SchemaVersion
+from cyclonedx.output import OutputFormat, SchemaVersion, get_instance
 from cyclonedx.output.xml import XmlV1Dot3, XmlV1Dot4
 
 

--- a/tests/test_output_json.py
+++ b/tests/test_output_json.py
@@ -16,18 +16,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from os.path import dirname, join
 from unittest.mock import Mock, patch
 
+from data import (
+    MOCK_UUID_1,
+    MOCK_UUID_2,
+    MOCK_UUID_3,
+    TEST_UUIDS,
+    get_bom_just_complete_metadata,
+    get_bom_with_component_setuptools_basic,
+    get_bom_with_component_setuptools_complete,
+    get_bom_with_component_setuptools_no_component_version,
+    get_bom_with_component_setuptools_with_cpe,
+    get_bom_with_component_setuptools_with_release_notes,
+    get_bom_with_component_setuptools_with_vulnerability,
+    get_bom_with_component_toml_1,
+    get_bom_with_external_references,
+    get_bom_with_nested_services,
+    get_bom_with_services_complex,
+    get_bom_with_services_simple,
+)
+
 from cyclonedx.exception.output import FormatNotSupportedException
 from cyclonedx.model.bom import Bom
-from cyclonedx.output import get_instance, OutputFormat, SchemaVersion
-from data import get_bom_with_component_setuptools_basic, get_bom_with_component_setuptools_with_cpe, \
-    get_bom_with_services_simple, get_bom_with_component_toml_1, \
-    get_bom_with_component_setuptools_no_component_version, \
-    get_bom_with_component_setuptools_with_release_notes, get_bom_with_component_setuptools_with_vulnerability, \
-    MOCK_UUID_1, get_bom_just_complete_metadata, MOCK_UUID_2, MOCK_UUID_3, TEST_UUIDS, get_bom_with_services_complex, \
-    get_bom_with_nested_services, get_bom_with_component_setuptools_complete, get_bom_with_external_references
+from cyclonedx.output import OutputFormat, SchemaVersion, get_instance
 from tests.base import BaseJsonTestCase
 
 

--- a/tests/test_output_xml.py
+++ b/tests/test_output_xml.py
@@ -16,17 +16,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
+
 from os.path import dirname, join
 from unittest.mock import Mock, patch
 
+from data import (
+    MOCK_UUID_1,
+    MOCK_UUID_4,
+    MOCK_UUID_5,
+    MOCK_UUID_6,
+    TEST_UUIDS,
+    get_bom_just_complete_metadata,
+    get_bom_with_component_setuptools_basic,
+    get_bom_with_component_setuptools_complete,
+    get_bom_with_component_setuptools_no_component_version,
+    get_bom_with_component_setuptools_with_cpe,
+    get_bom_with_component_setuptools_with_release_notes,
+    get_bom_with_component_setuptools_with_vulnerability,
+    get_bom_with_component_toml_1,
+    get_bom_with_external_references,
+    get_bom_with_nested_services,
+    get_bom_with_services_complex,
+    get_bom_with_services_simple,
+)
+
 from cyclonedx.model.bom import Bom
-from cyclonedx.output import get_instance, SchemaVersion
-from data import get_bom_with_component_setuptools_basic, get_bom_with_component_setuptools_with_cpe, \
-    get_bom_with_component_toml_1, get_bom_with_component_setuptools_no_component_version, \
-    get_bom_with_component_setuptools_with_release_notes, get_bom_with_component_setuptools_with_vulnerability, \
-    MOCK_UUID_1, MOCK_UUID_4, MOCK_UUID_5, MOCK_UUID_6, TEST_UUIDS, get_bom_just_complete_metadata, \
-    get_bom_with_nested_services, get_bom_with_services_simple, get_bom_with_services_complex, \
-    get_bom_with_component_setuptools_complete, get_bom_with_external_references
+from cyclonedx.output import SchemaVersion, get_instance
 from tests.base import BaseXmlTestCase
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,8 +41,10 @@ commands =
     poetry run flake8 cyclonedx/ tests/
 
 [flake8]
+## keep in sync with isort config - in `isort.cfg` file
 exclude =
-    build,dist,__pycache__,.eggs,*_cache
+    build,dist,__pycache__,.eggs,*.egg-info*,
+    *_cache,*.cache,
     .git,.tox,.venv,venv
     _OLD,_TEST,
     docs


### PR DESCRIPTION
fixes #85

* added QA tool: `isort`
* added QA tests: `flake8-isort`
* applied `isort` to all code, so  imports are sorted 