### PR TITLE
fix: `version` being optional in JSON output can raise error

### DIFF
--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -151,7 +151,8 @@ class Json(BaseOutput, BaseSchemaVersion):
                 if not self.component_supports_author() and 'author' in bom_json[base_key][i].keys():
                     del bom_json[base_key][i]['author']
 
-                if self.component_version_optional() and bom_json[base_key][i]['version'] == "":
+                if self.component_version_optional() and 'version' in bom_json[base_key][i].keys() and \
+                        bom_json[base_key][i]['version'] == "":
                     del bom_json[base_key][i]['version']
 
                 if not self.component_supports_pedigree() and 'pedigree' in bom_json[base_key][i].keys():

--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -151,7 +151,8 @@ class Json(BaseOutput, BaseSchemaVersion):
                 if not self.component_supports_author() and 'author' in bom_json[base_key][i].keys():
                     del bom_json[base_key][i]['author']
 
-                if self.component_version_optional() and bom_json[base_key][i].get('version', '') == "":
+                if self.component_version_optional() and 'version' in bom_json[base_key][i] \
+                        and bom_json[base_key][i].get('version', '') == "":
                     del bom_json[base_key][i]['version']
 
                 if not self.component_supports_pedigree() and 'pedigree' in bom_json[base_key][i].keys():

--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -151,8 +151,7 @@ class Json(BaseOutput, BaseSchemaVersion):
                 if not self.component_supports_author() and 'author' in bom_json[base_key][i].keys():
                     del bom_json[base_key][i]['author']
 
-                if self.component_version_optional() and 'version' in bom_json[base_key][i].keys() and \
-                        bom_json[base_key][i]['version'] == "":
+                if self.component_version_optional() and bom_json[base_key][i].get('version', '') == "":
                     del bom_json[base_key][i]['version']
 
                 if not self.component_supports_pedigree() and 'pedigree' in bom_json[base_key][i].keys():


### PR DESCRIPTION
Fixes
- #193 

Signed-off-by: Paul Horton <phorton@sonatype.com>