### PR TITLE
feat: reduce unnessessarry type casting of `set`/`SortedSet` when useing setter

### DIFF
--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -457,7 +457,7 @@ class ExternalReference:
         self.url = url
         self.comment = comment
         self.type = reference_type
-        self.hashes = SortedSet(hashes or [])
+        self.hashes = hashes or []  # type: ignore
 
     @property
     def url(self) -> XsUri:
@@ -1018,8 +1018,8 @@ class OrganizationalEntity:
                 'One of name, urls or contacts must be supplied for an OrganizationalEntity - none supplied.'
             )
         self.name = name
-        self.url = SortedSet(urls or [])
-        self.contact = SortedSet(contacts or [])
+        self.url = urls or []  # type: ignore
+        self.contact = contacts or []  # type: ignore
 
     @property
     def name(self) -> Optional[str]:
@@ -1091,8 +1091,8 @@ class Tool:
         self.vendor = vendor
         self.name = name
         self.version = version
-        self.hashes = SortedSet(hashes or [])
-        self.external_references = SortedSet(external_references or [])
+        self.hashes = hashes or []  # type: ignore
+        self.external_references = external_references or []  # type: ignore
 
     @property
     def vendor(self) -> Optional[str]:

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -45,13 +45,13 @@ class BomMetaData:
                  licenses: Optional[Iterable[LicenseChoice]] = None,
                  properties: Optional[Iterable[Property]] = None) -> None:
         self.timestamp = datetime.now(tz=timezone.utc)
-        self.tools = SortedSet(tools or [])
-        self.authors = SortedSet(authors or [])
+        self.tools = tools or []  # type: ignore
+        self.authors = authors or []  # type: ignore
         self.component = component
         self.manufacture = manufacture
         self.supplier = supplier
-        self.licenses = SortedSet(licenses or [])
-        self.properties = SortedSet(properties or [])
+        self.licenses = licenses or []  # type: ignore
+        self.properties = properties or []  # type: ignore
 
         if not tools:
             self.tools.add(ThisTool)
@@ -239,9 +239,9 @@ class Bom:
         """
         self.uuid = uuid4()
         self.metadata = BomMetaData()
-        self.components = SortedSet(components or [])
-        self.services = SortedSet(services or [])
-        self.external_references = SortedSet(external_references or [])
+        self.components = components or []  # type: ignore
+        self.services = services or []  # type: ignore
+        self.external_references = external_references or []  # type: ignore
 
     @property
     def uuid(self) -> UUID:

--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -175,8 +175,8 @@ class ComponentEvidence:
                 'At least one of `licenses` or `copyright_` must be supplied for a `ComponentEvidence`.'
             )
 
-        self.licenses = SortedSet(licenses or [])
-        self.copyright = SortedSet(copyright_ or [])
+        self.licenses = licenses or []  # type: ignore
+        self.copyright = copyright_ or []  # type: ignore
 
     @property
     def licenses(self) -> "SortedSet[LicenseChoice]":
@@ -334,7 +334,7 @@ class Patch:
                  resolves: Optional[Iterable[IssueType]] = None) -> None:
         self.type = type_
         self.diff = diff
-        self.resolves = SortedSet(resolves or [])
+        self.resolves = resolves or []  # type: ignore
 
     @property
     def type(self) -> PatchClassification:
@@ -423,11 +423,11 @@ class Pedigree:
                 'provided for `Pedigree`'
             )
 
-        self.ancestors = SortedSet(ancestors or [])
-        self.descendants = SortedSet(descendants or [])
-        self.variants = SortedSet(variants or [])
-        self.commits = SortedSet(commits or [])
-        self.patches = SortedSet(patches or [])
+        self.ancestors = ancestors or []  # type: ignore
+        self.descendants = descendants or []  # type: ignore
+        self.variants = variants or []  # type: ignore
+        self.commits = commits or []  # type: ignore
+        self.patches = patches or []  # type: ignore
         self.notes = notes
 
     @property
@@ -732,16 +732,16 @@ class Component:
         self.version = version
         self.description = description
         self.scope = scope
-        self.hashes = SortedSet(hashes or [])
-        self.licenses = SortedSet(licenses or [])
+        self.hashes = hashes or []  # type: ignore
+        self.licenses = licenses or []  # type: ignore
         self.copyright = copyright_
         self.cpe = cpe
         self.purl = purl
         self.swid = swid
         self.pedigree = pedigree
-        self.external_references = SortedSet(external_references or [])
-        self.properties = SortedSet(properties or [])
-        self.components = SortedSet(components or [])
+        self.external_references = external_references or []  # type: ignore
+        self.properties = properties or []  # type: ignore
+        self.components = components or []  # type: ignore
         self.evidence = evidence
         self.release_notes = release_notes
 
@@ -760,7 +760,7 @@ class Component:
                 'standard', DeprecationWarning
             )
             if not licenses:
-                self.licenses = SortedSet([LicenseChoice(license_expression=license_str)])
+                self.licenses = [LicenseChoice(license_expression=license_str)]  # type: ignore
 
         self.__dependencies: "SortedSet[BomRef]" = SortedSet()
         self.__vulnerabilites: "SortedSet[Vulnerability]" = SortedSet()

--- a/cyclonedx/model/dependency.py
+++ b/cyclonedx/model/dependency.py
@@ -34,7 +34,7 @@ class Dependency:
 
     def __init__(self, *, ref: BomRef, depends_on: Optional[Iterable[BomRef]] = None) -> None:
         self._ref = ref
-        self.depends_on = SortedSet(depends_on or [])
+        self.depends_on = depends_on or []  # type: ignore
 
     @property
     def ref(self) -> BomRef:

--- a/cyclonedx/model/issue.py
+++ b/cyclonedx/model/issue.py
@@ -115,7 +115,7 @@ class IssueType:
         self.name = name
         self.description = description
         self.source = source
-        self.references = SortedSet(references or [])
+        self.references = references or []  # type: ignore
 
     @property
     def type(self) -> IssueClassification:

--- a/cyclonedx/model/release_note.py
+++ b/cyclonedx/model/release_note.py
@@ -45,11 +45,11 @@ class ReleaseNotes:
         self.social_image = social_image
         self.description = description
         self.timestamp = timestamp
-        self.aliases = SortedSet(aliases or [])
-        self.tags = SortedSet(tags or [])
-        self.resolves = SortedSet(resolves or [])
-        self.notes = SortedSet(notes or [])
-        self.properties = SortedSet(properties or [])
+        self.aliases = aliases or []  # type: ignore
+        self.tags = tags or []  # type: ignore
+        self.resolves = resolves or []  # type: ignore
+        self.notes = notes or []  # type: ignore
+        self.properties = properties or []  # type: ignore
 
     @property
     def type(self) -> str:

--- a/cyclonedx/model/service.py
+++ b/cyclonedx/model/service.py
@@ -63,15 +63,15 @@ class Service:
         self.name = name
         self.version = version
         self.description = description
-        self.endpoints = SortedSet(endpoints or [])
+        self.endpoints = endpoints or []  # type: ignore
         self.authenticated = authenticated
         self.x_trust_boundary = x_trust_boundary
-        self.data = SortedSet(data or [])
-        self.licenses = SortedSet(licenses or [])
-        self.external_references = SortedSet(external_references or [])
-        self.services = SortedSet(services or [])
+        self.data = data or []  # type: ignore
+        self.licenses = licenses or []  # type: ignore
+        self.external_references = external_references or []  # type: ignore
+        self.services = services or []  # type: ignore
         self.release_notes = release_notes
-        self.properties = SortedSet(properties or [])
+        self.properties = properties or []  # type: ignore
 
     @property
     def bom_ref(self) -> BomRef:

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -144,7 +144,7 @@ class BomTarget:
 
     def __init__(self, *, ref: str, versions: Optional[Iterable[BomTargetVersionRange]] = None) -> None:
         self.ref = ref
-        self.versions = SortedSet(versions or [])
+        self.versions = versions or []  # type: ignore
 
     @property
     def ref(self) -> str:
@@ -207,7 +207,7 @@ class VulnerabilityAnalysis:
             )
         self.state = state
         self.justification = justification
-        self.response = SortedSet(responses or [])
+        self.response = responses or []  # type: ignore
         self.detail = detail
 
     @property
@@ -719,8 +719,8 @@ class VulnerabilityCredits:
             raise NoPropertiesProvidedException(
                 'One of `organizations` or `individuals` must be populated - neither were'
             )
-        self.organizations = SortedSet(organizations or [])
-        self.individuals = SortedSet(individuals or [])
+        self.organizations = organizations or []  # type: ignore
+        self.individuals = individuals or []  # type: ignore
 
     @property
     def organizations(self) -> "SortedSet[OrganizationalEntity]":
@@ -789,20 +789,20 @@ class Vulnerability:
         self._bom_ref = BomRef(value=bom_ref)
         self.id = id
         self.source = source
-        self.references = SortedSet(references or [])
-        self.ratings = SortedSet(ratings or [])
-        self.cwes = SortedSet(cwes or [])
+        self.references = references or []  # type: ignore
+        self.ratings = ratings or []  # type: ignore
+        self.cwes = cwes or []  # type: ignore
         self.description = description
         self.detail = detail
         self.recommendation = recommendation
-        self.advisories = SortedSet(advisories or [])
+        self.advisories = advisories or []  # type: ignore
         self.created = created
         self.published = published
         self.updated = updated
         self.credits = credits
-        self.tools = SortedSet(tools or [])
+        self.tools = tools or []  # type: ignore
         self.analysis = analysis
-        self.affects = SortedSet(affects_targets or [])
+        self.affects = affects_targets or []  # type: ignore
 
         if source_name or source_url:
             warnings.warn('`source_name` and `source_url` are deprecated - use `source`', DeprecationWarning)


### PR DESCRIPTION
show what would happen, if the unnecessary type cast of `set`/`SortedSet` was omitted.

unnecessary on runtime (as all unit/functional/integration tests are passing), 
but `mypy` is not able to detect that the setter has a _wider_ type definition than the getter... 
see the issue https://github.com/python/mypy/issues/3004 
and the decision that the issue is a feature-lack/bug: https://github.com/python/mypy/issues/3004#issuecomment-562073403

this PR is intended to last for a while and be rebased, whenever needed, 
to test if mypy implemented the missing feature, some day.

