### PR TITLE
feat(deps): remove unused `typing-extensions` constraints

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -411,11 +411,11 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.2"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.1.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "virtualenv"
@@ -464,7 +464,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "057af4b7e45bb1b2bc18ed216f5c924366c661b4e5b72dd98d1bec36527d2c6d"
+content-hash = "fc30fe864bbb03530811d7e92028f222de26252b34ab73cb121368d897eb60f6"
 
 [metadata.files]
 attrs = [
@@ -774,9 +774,8 @@ types-toml = [
     {file = "types_toml-0.10.4-py3-none-any.whl", hash = "sha256:4a9ffd47bbcec49c6fde6351a889b2c1bd3c0ef309fa0eed60dc28e58c8b9ea6"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
-    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
-    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
 virtualenv = [
     {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ packageurl-python = ">= 0.9"
 setuptools = ">= 47.0.0"
 importlib-metadata = { version = ">= 3.4", python = "< 3.8" }
 toml = "^0.10.0"
-# `typing-extensions` need to stay in sync with major version of `python`
-typing-extensions = { version = "^3.10", python = "< 3.8" }
 # `types-setuptools` need to stay in sync with version of `setuptools` - but 47 was not typed...
 types-setuptools = ">= 57.0.0"
 # `types-toml` need to stay in sync with version of `toml`

--- a/requirements.lowest.txt
+++ b/requirements.lowest.txt
@@ -5,6 +5,5 @@ packageurl-python == 0.9.0
 setuptools == 47.0.0
 importlib-metadata == 3.4.0 # ; python_version < '3.8'
 toml == 0.10.0
-typing-extensions == 3.10.0 # ; python_version < '3.8'
 types-setuptools == 57.0.0
 types-toml == 0.10.0


### PR DESCRIPTION
To be able to use new types, which will be introduced in Python 3.11, the package version shouldn't be pinned to `3.10.x` and the package can be installed with any Python version, because you can't know, what the user will use. Here is the official explanation on version pinning

> Starting with version 4.0.0, typing_extensions uses [Semantic Versioning](https://semver.org/). The major version is incremented for all backwards-incompatible changes. Therefore, it’s safe to depend on typing_extensions like this: typing_extensions >=x.y, <(x+1), where x.y is the first version that includes all features you need.  