### PR TITLE
ci: pin GH-action `semantic-release` to v7.28.1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,13 @@ jobs:
     concurrency: release
     steps:
       - name: Checkout code
+        # see https://github.com/actions/checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - name: Setup python
+        # see https://github.com/actions/setup-python
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -29,8 +32,11 @@ jobs:
       - name: View poetry version
         run: poetry --version
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@master
+        # see https://python-semantic-release.readthedocs.io/en/latest/automatic-releases/github-actions.html
+        # see https://github.com/relekang/python-semantic-release
+        uses: relekang/python-semantic-release@v7.28.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
-
+          repository_username: __token__
+          repository_password: ${{ secrets.PYPI_TOKEN }}
+          pypi_token:          ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
see also: https://github.com/relekang/python-semantic-release/issues/442