### PR TITLE
fix: type hint for get_component_by_purl is incorrect

### DIFF
--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -18,7 +18,7 @@
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 import warnings
 from datetime import datetime, timezone
-from typing import Iterable, Optional, Set
+from typing import TYPE_CHECKING, Iterable, Optional, Set
 from uuid import UUID, uuid4
 
 from sortedcontainers import SortedSet
@@ -28,6 +28,9 @@ from ..parser import BaseParser
 from . import ExternalReference, LicenseChoice, OrganizationalContact, OrganizationalEntity, Property, ThisTool, Tool
 from .component import Component
 from .service import Service
+
+if TYPE_CHECKING:
+    from packageurl import PackageURL  # type:ignore[import]
 
 
 class BomMetaData:
@@ -288,19 +291,19 @@ class Bom:
     def components(self, components: Iterable[Component]) -> None:
         self._components = SortedSet(components)
 
-    def get_component_by_purl(self, purl: Optional[str]) -> Optional[Component]:
+    def get_component_by_purl(self, purl: Optional["PackageURL"]) -> Optional[Component]:
         """
         Get a Component already in the Bom by its PURL
 
         Args:
              purl:
-                Package URL as a `str` to look and find `Component`
+                An instance of `packageurl.PackageURL` to look and find `Component`.
 
         Returns:
             `Component` or `None`
         """
         if purl:
-            found = list(filter(lambda x: x.purl == purl, self.components))
+            found = [x for x in self.components if x.purl == purl]
             if len(found) == 1:
                 return found[0]
 

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -24,9 +24,8 @@ from unittest import TestCase
 from packageurl import PackageURL  # type: ignore
 
 from cyclonedx.model import sha1sum
-from cyclonedx.model.bom import Bom
 from cyclonedx.model.component import Component
-from data import get_component_setuptools_simple, get_component_setuptools_simple_no_version
+from data import get_component_setuptools_simple
 
 FIXTURES_DIRECTORY = 'fixtures/xml/1.4'
 
@@ -78,20 +77,3 @@ class TestComponent(TestCase):
         )
         self.assertEqual(c.purl, purl)
         self.assertEqual(len(c.hashes), 1)
-
-    def test_has_component_1(self) -> None:
-        bom = Bom()
-        bom.components.update([get_component_setuptools_simple(), get_component_setuptools_simple_no_version()])
-        self.assertEqual(len(bom.components), 2)
-        self.assertTrue(bom.has_component(component=get_component_setuptools_simple_no_version()))
-        self.assertIsNot(get_component_setuptools_simple(), get_component_setuptools_simple_no_version())
-
-    def test_get_component_by_purl(self) -> None:
-        bom = Bom()
-        setuptools_simple = get_component_setuptools_simple()
-        bom.components.add(get_component_setuptools_simple())
-
-        result = bom.get_component_by_purl(get_component_setuptools_simple().purl)
-
-        self.assertEqual(result, setuptools_simple)
-        self.assertIsNone(bom.get_component_by_purl(get_component_setuptools_simple_no_version().purl))

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -85,3 +85,13 @@ class TestComponent(TestCase):
         self.assertEqual(len(bom.components), 2)
         self.assertTrue(bom.has_component(component=get_component_setuptools_simple_no_version()))
         self.assertIsNot(get_component_setuptools_simple(), get_component_setuptools_simple_no_version())
+
+    def test_get_component_by_purl(self) -> None:
+        bom = Bom()
+        setuptools_simple = get_component_setuptools_simple()
+        bom.components.add(get_component_setuptools_simple())
+
+        result = bom.get_component_by_purl(get_component_setuptools_simple().purl)
+
+        self.assertEqual(result, setuptools_simple)
+        self.assertIsNone(bom.get_component_by_purl(get_component_setuptools_simple_no_version().purl))

--- a/tests/test_model_bom.py
+++ b/tests/test_model_bom.py
@@ -22,7 +22,12 @@ from unittest import TestCase
 from cyclonedx.model import License, LicenseChoice, OrganizationalContact, OrganizationalEntity, Property
 from cyclonedx.model.bom import Bom, BomMetaData, ThisTool, Tool
 from cyclonedx.model.component import Component, ComponentType
-from data import get_bom_for_issue_275_components, get_bom_with_component_setuptools_with_vulnerability
+from data import (
+    get_bom_for_issue_275_components,
+    get_bom_with_component_setuptools_with_vulnerability,
+    get_component_setuptools_simple,
+    get_component_setuptools_simple_no_version,
+)
 
 
 class TestBomMetaData(TestCase):
@@ -127,3 +132,20 @@ class TestBom(TestCase):
     #     self.assertIsInstance(bom.metadata.component, Component)
     #     self.assertEqual(2, len(bom.services))
     #     bom.validate()
+
+    def test_has_component_1(self) -> None:
+        bom = Bom()
+        bom.components.update([get_component_setuptools_simple(), get_component_setuptools_simple_no_version()])
+        self.assertEqual(len(bom.components), 2)
+        self.assertTrue(bom.has_component(component=get_component_setuptools_simple_no_version()))
+        self.assertIsNot(get_component_setuptools_simple(), get_component_setuptools_simple_no_version())
+
+    def test_get_component_by_purl(self) -> None:
+        bom = Bom()
+        setuptools_simple = get_component_setuptools_simple()
+        bom.components.add(setuptools_simple)
+
+        result = bom.get_component_by_purl(get_component_setuptools_simple().purl)
+
+        self.assertIs(result, setuptools_simple)
+        self.assertIsNone(bom.get_component_by_purl(get_component_setuptools_simple_no_version().purl))


### PR DESCRIPTION
Signed-off-by: gruebel <anton.gruebel@gmail.com>

- adjusted the type hint for `get_component_by_purl` and added a test for it 🙂 
- changed the list/filter expression to use a list comprehension, which is almost 2x faster in this case 🚀 