### PR TITLE
feat: Make JSON output diff friendly

### DIFF
--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -92,7 +92,7 @@ class Json(BaseOutput, BaseSchemaVersion):
 
         bom_json = json.loads(json.dumps(bom, cls=CycloneDxJSONEncoder))
         bom_json = json.loads(self._specialise_output_for_schema_version(bom_json=bom_json))
-        self._json_output = json.dumps({**self._create_bom_element(), **bom_json, **extras})
+        self._json_output = json.dumps({**self._create_bom_element(), **bom_json, **extras}, indent=2)
 
         self.generated = True
 

--- a/tests/test_output_json.py
+++ b/tests/test_output_json.py
@@ -371,6 +371,15 @@ class TestOutputJson(BaseJsonTestCase):
             fixture='bom_issue_275_components.json'
         )
 
+    def test_pretty_json(self) -> None:
+        bom = get_bom_with_dependencies_valid()
+        schema_version = SchemaVersion.V1_4
+        outputter = get_instance(bom=bom, output_format=OutputFormat.JSON, schema_version=schema_version)
+        output = outputter.output_as_string()
+
+        lines = output.splitlines()
+        assert(len(lines) > 1)
+
     # Helper methods
     def _validate_json_bom(self, bom: Bom, schema_version: SchemaVersion, fixture: str) -> None:
         outputter = get_instance(bom=bom, output_format=OutputFormat.JSON, schema_version=schema_version)


### PR DESCRIPTION
Pretty-print JSON output, with an indent of 2.
Up until now, JSON output is a single line, which is not diff friendly.

Addresses [cyclonedx-python/issues/424](https://github.com/CycloneDX/cyclonedx-python/issues/424) for JSON.
