### PR TITLE
test: minimal json schema only with required fields

### DIFF
--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -367,7 +367,7 @@ class Bom:
 
     def _get_all_components(self) -> Set[Component]:
         components: Set[Component] = set()
-        if self.metadata.component:
+        if self.metadata and self.metadata.component:
             components.update(self.metadata.component.get_all_nested_components(include_self=True))
 
         for c in self.components:
@@ -448,7 +448,7 @@ class Bom:
                 f'BOM. They are: {dependency_diff}')
 
         # 2. Dependencies should exist for the Component this BOM is describing, if one is set
-        if self.metadata.component and not self.metadata.component.dependencies:
+        if self.metadata and self.metadata.component and not self.metadata.component.dependencies:
             warnings.warn(
                 f'The Component this BOM is describing {self.metadata.component.purl} has no defined dependencies '
                 f'which means the Dependency Graph is incomplete - you should add direct dependencies to this Component'

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -253,7 +253,7 @@ class Bom:
         self.version = version
 
     @property
-    def uuid(self) -> UUID:
+    def uuid(self) -> Optional[UUID]:
         """
         Unique UUID for this BOM
 
@@ -263,11 +263,11 @@ class Bom:
         return self.__uuid
 
     @uuid.setter
-    def uuid(self, uuid: UUID) -> None:
+    def uuid(self, uuid: Optional[UUID]) -> None:
         self.__uuid = uuid
 
     @property
-    def metadata(self) -> BomMetaData:
+    def metadata(self) -> Optional[BomMetaData]:
         """
         Get our internal metadata object for this Bom.
 
@@ -280,7 +280,7 @@ class Bom:
         return self._metadata
 
     @metadata.setter
-    def metadata(self, metadata: BomMetaData) -> None:
+    def metadata(self, metadata: Optional[BomMetaData]) -> None:
         self._metadata = metadata
 
     @property
@@ -315,14 +315,15 @@ class Bom:
 
         return None
 
-    def get_urn_uuid(self) -> str:
+    def get_urn_uuid(self) -> Optional[str]:
         """
         Get the unique reference for this Bom.
 
         Returns:
             URN formatted UUID that uniquely identified this Bom instance.
         """
-        return self.__uuid.urn
+        if self.__uuid:
+            return self.__uuid.urn
 
     def has_component(self, component: Component) -> bool:
         """

--- a/cyclonedx/output/json.py
+++ b/cyclonedx/output/json.py
@@ -66,7 +66,7 @@ class Json(BaseOutput, BaseSchemaVersion):
         extras = {}
         if self.bom_supports_dependencies():
             dep_components = self._chained_components(bom)
-            if bom.metadata.component:
+            if bom.metadata and bom.metadata.component:
                 dep_components = [bom.metadata.component, *dep_components]
             dependencies = []
             for component in dep_components:

--- a/tests/data.py
+++ b/tests/data.py
@@ -341,6 +341,13 @@ def get_bom_for_issue_275_components() -> Bom:
     return bom
 
 
+def get_bom_minimal() -> Bom:
+    bom = Bom()
+    bom.uuid = None
+    bom.metadata = None
+    return bom
+
+
 # def get_bom_for_issue_275_services() -> Bom:
 #    """regression test for issue #275
 #    see https://github.com/CycloneDX/cyclonedx-python-lib/issues/275

--- a/tests/fixtures/json/1.2/bom_minimal_only_required.json
+++ b/tests/fixtures/json/1.2/bom_minimal_only_required.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.2b.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.2",
+  "version": 1
+}

--- a/tests/fixtures/json/1.3/bom_minimal_only_required.json
+++ b/tests/fixtures/json/1.3/bom_minimal_only_required.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.3a.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.3",
+  "version": 1
+}

--- a/tests/fixtures/json/1.4/bom_minimal_only_required.json
+++ b/tests/fixtures/json/1.4/bom_minimal_only_required.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/test_output_json.py
+++ b/tests/test_output_json.py
@@ -50,6 +50,7 @@ from .data import (
     get_bom_with_nested_services,
     get_bom_with_services_complex,
     get_bom_with_services_simple,
+    get_bom_minimal,
 )
 
 
@@ -391,6 +392,24 @@ class TestOutputJson(BaseJsonTestCase):
         self._validate_json_bom(
             bom=get_bom_for_issue_328_components(), schema_version=SchemaVersion.V1_2,
             fixture='bom_issue_328_components.json'
+        )
+
+    def test_bom_minimal_with_only_required_fields_v1_2(self) -> None:
+        self._validate_json_bom(
+            bom=get_bom_minimal(), schema_version=SchemaVersion.V1_2,
+            fixture='bom_minimal_only_required.json'
+        )
+
+    def test_bom_minimal_with_only_required_fields_v1_3(self) -> None:
+        self._validate_json_bom(
+            bom=get_bom_minimal(), schema_version=SchemaVersion.V1_3,
+            fixture='bom_minimal_only_required.json'
+        )
+
+    def test_bom_minimal_with_only_required_fields_v1_4(self) -> None:
+        self._validate_json_bom(
+            bom=get_bom_minimal(), schema_version=SchemaVersion.V1_4,
+            fixture='bom_external_references.json'
         )
 
     # region Helper methods


### PR DESCRIPTION
According to [the json schema](https://cyclonedx.org/docs/1.4/json/) only the `bomFormat`, `specVersion` and `version` fields are required. `serialNumber`  (`bom.uuid` which is RECOMMENDED but not REQUIRED), `metadata and `externalReferences` could be empty.

I've put some fixtures and tests together which only have those required fields according to the spec. The tests are unfortunately failing due to several reasons:
 - `metadata` is always assumed to be there. It could be empty or `None`. 
   - Tweaked this in the `assertEqualJsonBom` method in [tests/base.py](tests/base.py). See 0916ff38c0ddb94cde1f18182fe8b40dfc6d8c7c and
   - in several places where metadata is accessed. see 573357f2ad49aeeb5bef1a644c09c9390f6f39cd
 - `serialNumber`  (`bom.uuid`) is also assumed to exist for the tests.

I know this is an edge case which does not make any sense but one or another field which is not required should be empty.

I was not sure if I'd open an issue for this. I think a PR is better where we could start the discussion with some examples.