### PR TITLE
chore: do not ship exra LICENSE file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ packages = [
 ]
 include = [
   { path = "tests", format = "sdist" },
-  "LICENSE",
 ]
 classifiers = [
   # Trove classifiers - https://packaging.python.org/specifications/core-metadata/#metadata-classifier


### PR DESCRIPTION
fixes https://github.com/CycloneDX/cyclonedx-python-lib/issues/336#issuecomment-1380688129

poetry will detect the `LICENSE` file automatically and put it in the bundle somewhere.
so we are still good, when we dont pack it in the root explicitly. 