### PR TITLE
fix: `bom.validate()` detects invalid license constellations

### DIFF
--- a/cyclonedx/exception/model.py
+++ b/cyclonedx/exception/model.py
@@ -73,10 +73,21 @@ class UnknownComponentDependencyException(CycloneDxModelException):
     """
     Exception raised when a dependency has been noted for a Component that is NOT a Component BomRef in this Bom.
     """
+    pass
 
 
 class UnknownHashTypeException(CycloneDxModelException):
     """
     Exception raised when we are unable to determine the type of hash from a composite hash string.
+    """
+    pass
+
+
+class LicenseExpressionAlongWithOthersException(CycloneDxModelException):
+    """
+    Exception raised when a LicenseExpression was detected along with other licenses.
+    If a LicenseExpression exists, than it must stand alone.
+
+    See https://github.com/CycloneDX/specification/pull/205
     """
     pass

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -574,7 +574,7 @@ class Bom:
                 UserWarning
             )
 
-        # 3. If a LicenseExpression is set. then there must be no other license.
+        # 3. If a LicenseExpression is set, then there must be no other license.
         # see https://github.com/CycloneDX/specification/pull/205
         elem: Union[BomMetaData, Component, Service]
         for elem in chain(  # type: ignore[assignment]

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -576,8 +576,9 @@ class Bom:
 
         # 3. If a LicenseExpression is set. then there must be no other license.
         # see https://github.com/CycloneDX/specification/pull/205
-        elem: Union[Component, Service]
+        elem: Union[BomMetaData, Component, Service]
         for elem in chain(  # type: ignore[assignment]
+            [self.metadata],
             self.metadata.component.get_all_nested_components(include_self=True) if self.metadata.component else [],
             chain.from_iterable(c.get_all_nested_components(include_self=True) for c in self.components),
             self.services

--- a/tests/data.py
+++ b/tests/data.py
@@ -640,6 +640,59 @@ def get_vulnerability_source_owasp() -> VulnerabilitySource:
     return VulnerabilitySource(name='OWASP', url=XsUri('https://owasp.org'))
 
 
+def get_bom_metadata_licenses_invalid() -> Bom:
+    return Bom(metadata=BomMetaData(licenses=[
+        LicenseChoice(expression='Apache-2.0 OR MIT'),
+        LicenseChoice(license=License(id='MIT')),
+    ]))
+
+
+def get_invalid_license_repository() -> List[LicenseChoice]:
+    """
+    license expression and a license -- this is an invalid constellation according to schema
+    see https://github.com/CycloneDX/specification/pull/205
+    """
+    return [
+        LicenseChoice(expression='Apache-2.0 OR MIT'),
+        LicenseChoice(license=License(id='GPL-2.0-only')),
+    ]
+
+
+def get_component_licenses_invalid() -> Component:
+    return Component(name='foo', type=ComponentType.LIBRARY,
+                     licenses=get_invalid_license_repository())
+
+
+def get_bom_metadata_component_licenses_invalid() -> Bom:
+    comp = get_component_licenses_invalid()
+    return Bom(metadata=BomMetaData(component=comp),
+               dependencies=[Dependency(comp.bom_ref)])
+
+
+def get_bom_metadata_component_nested_licenses_invalid() -> Bom:
+    comp = Component(name='bar', type=ComponentType.LIBRARY,
+                     components=[get_component_licenses_invalid()])
+    return Bom(metadata=BomMetaData(component=comp),
+               dependencies=[Dependency(comp.bom_ref)])
+
+
+def get_bom_component_licenses_invalid() -> Bom:
+    return Bom(components=[get_component_licenses_invalid()])
+
+
+def get_bom_component_nested_licenses_invalid() -> Bom:
+    return Bom(components=[
+        Component(name='bar', type=ComponentType.LIBRARY,
+                  components=[get_component_licenses_invalid()])
+    ])
+
+
+def get_bom_service_licenses_invalid() -> Bom:
+    return Bom(services=[
+        Service(name='foo', licenses=get_invalid_license_repository())
+    ])
+
+
 T = TypeVar('T')
 
 

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -52,5 +52,5 @@ class TestGetInstance(TestCase):
     )
     @unpack
     def test_fails_on_wrong_args(self, of: OutputFormat, sv: SchemaVersion, raisesRegex: Tuple) -> None:
-        with self.assertRaisesRegexp(*raisesRegex):
+        with self.assertRaisesRegex(*raisesRegex):
             get_validator(of, sv)


### PR DESCRIPTION
If a LicenseExpression is set, then there must be no other license.

fixes #453