### PR TITLE
refactor: schema based validator

### DIFF
--- a/cyclonedx/output/__init__.py
+++ b/cyclonedx/output/__init__.py
@@ -129,7 +129,7 @@ def get_instance(bom: 'Bom', output_format: OutputFormat = OutputFormat.XML,
     :return: BaseOutput
     """
     # all exceptions are undocumented, as they are pure functional, and should be prevented by correct typing...
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:  # pragma: no cover
         BY_SCHEMA_VERSION: Mapping[SchemaVersion, Type[BaseOutput]]
     if OutputFormat.JSON is output_format:
         from .json import BY_SCHEMA_VERSION

--- a/cyclonedx/output/__init__.py
+++ b/cyclonedx/output/__init__.py
@@ -138,7 +138,7 @@ def get_instance(bom: 'Bom', output_format: OutputFormat = OutputFormat.XML,
     else:
         raise ValueError(f"Unexpected output_format: {output_format!r}")
 
-    klass: Type[BaseOutput] = BY_SCHEMA_VERSION.get(schema_version, None)
+    klass = BY_SCHEMA_VERSION.get(schema_version, None)
     if klass is None:
         raise ValueError(f'Unknown {output_format.name}/schema_version: {schema_version!r}')
     return klass(bom)

--- a/cyclonedx/validation/json.py
+++ b/cyclonedx/validation/json.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 from ..exception import MissingOptionalDependencyException
 from ..schema._res import BOM_JSON as _S_BOM, BOM_JSON_STRICT as _S_BOM_STRICT, JSF as _S_JSF, SPDX_JSON as _S_SPDX
-from . import BaseValidator, ValidationError, Validator
+from . import BaseSchemaBasedValidator, SchemaBasedValidator, ValidationError
 
 _missing_deps_error: Optional[Tuple[MissingOptionalDependencyException, ImportError]] = None
 try:
@@ -45,7 +45,7 @@ except ImportError as err:
     ), err
 
 
-class _BaseJsonValidator(BaseValidator, ABC):
+class _BaseJsonValidator(BaseSchemaBasedValidator, ABC):
     @property
     def output_format(self) -> Literal[OutputFormat.JSON]:
         return OutputFormat.JSON
@@ -98,7 +98,7 @@ class _BaseJsonValidator(BaseValidator, ABC):
                 ])
 
 
-class JsonValidator(_BaseJsonValidator, Validator):
+class JsonValidator(_BaseJsonValidator, SchemaBasedValidator):
     """Validator for CycloneDX documents in JSON format."""
 
     @property
@@ -106,7 +106,7 @@ class JsonValidator(_BaseJsonValidator, Validator):
         return _S_BOM.get(self.schema_version)
 
 
-class JsonStrictValidator(_BaseJsonValidator, Validator):
+class JsonStrictValidator(_BaseJsonValidator, SchemaBasedValidator):
     """Strict validator for CycloneDX documents in JSON format.
 
     In contrast to :class:`~JsonValidator`,

--- a/cyclonedx/validation/json.py
+++ b/cyclonedx/validation/json.py
@@ -98,7 +98,7 @@ class _BaseJsonValidator(BaseSchemaBasedValidator, ABC):
                 ])
 
 
-class JsonValidator(_BaseJsonValidator, SchemaBasedValidator):
+class JsonValidator(_BaseJsonValidator, BaseSchemaBasedValidator, SchemaBasedValidator):
     """Validator for CycloneDX documents in JSON format."""
 
     @property
@@ -106,7 +106,7 @@ class JsonValidator(_BaseJsonValidator, SchemaBasedValidator):
         return _S_BOM.get(self.schema_version)
 
 
-class JsonStrictValidator(_BaseJsonValidator, SchemaBasedValidator):
+class JsonStrictValidator(_BaseJsonValidator, BaseSchemaBasedValidator, SchemaBasedValidator):
     """Strict validator for CycloneDX documents in JSON format.
 
     In contrast to :class:`~JsonValidator`,

--- a/cyclonedx/validation/model.py
+++ b/cyclonedx/validation/model.py
@@ -1,0 +1,20 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+
+# nothing here, yet.
+# in the future this could be the place where model validation is done.
+# like the current `model.bom.Bom.validate()`
+# see also: https://github.com/CycloneDX/cyclonedx-python-lib/issues/455

--- a/cyclonedx/validation/schema.py
+++ b/cyclonedx/validation/schema.py
@@ -1,0 +1,61 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+
+from typing import TYPE_CHECKING, Literal, Union, overload
+
+from ..schema import OutputFormat
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..schema import SchemaVersion
+    from . import BaseSchemaBasedValidator
+    from .json import JsonValidator
+    from .xml import XmlValidator
+
+
+@overload
+def get_instance(output_format: Literal[OutputFormat.JSON], schema_version: 'SchemaVersion'
+                 ) -> 'JsonValidator':
+    ...
+
+
+@overload
+def get_instance(output_format: Literal[OutputFormat.XML], schema_version: 'SchemaVersion'
+                 ) -> 'XmlValidator':
+    ...
+
+
+@overload
+def get_instance(output_format: OutputFormat, schema_version: 'SchemaVersion'
+                 ) -> Union['JsonValidator', 'XmlValidator']:
+    ...
+
+
+def get_instance(output_format: OutputFormat, schema_version: 'SchemaVersion') -> 'BaseSchemaBasedValidator':
+    """get the default schema-based validator for a certain `OutputFormat`
+
+    Raises error when no instance could be built.
+    """
+    # all exceptions are undocumented, as they are pure functional, and should be prevented by correct typing...
+    if TYPE_CHECKING:
+        from typing import Type
+        Validator: Type[BaseSchemaBasedValidator]
+    if OutputFormat.JSON is output_format:
+        from .json import JsonValidator as Validator
+    elif OutputFormat.XML is output_format:
+        from .xml import XmlValidator as Validator
+    else:
+        raise ValueError(f'Unexpected output_format: {output_format!r}')
+    return Validator(schema_version)

--- a/cyclonedx/validation/schema.py
+++ b/cyclonedx/validation/schema.py
@@ -49,7 +49,7 @@ def get_instance(output_format: OutputFormat, schema_version: 'SchemaVersion') -
     Raises error when no instance could be built.
     """
     # all exceptions are undocumented, as they are pure functional, and should be prevented by correct typing...
-    if TYPE_CHECKING:
+    if TYPE_CHECKING:  # pragma: no cover
         from typing import Type
         Validator: Type[BaseSchemaBasedValidator]
     if OutputFormat.JSON is output_format:

--- a/cyclonedx/validation/xml.py
+++ b/cyclonedx/validation/xml.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional, Tuple
 from ..exception import MissingOptionalDependencyException
 from ..schema import OutputFormat
 from ..schema._res import BOM_XML as _S_BOM
-from . import BaseValidator, ValidationError, Validator
+from . import BaseSchemaBasedValidator, SchemaBasedValidator, ValidationError
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..schema import SchemaVersion
@@ -37,7 +37,7 @@ except ImportError as err:
     ), err
 
 
-class _BaseXmlValidator(BaseValidator, ABC):
+class _BaseXmlValidator(BaseSchemaBasedValidator, ABC):
 
     @property
     def output_format(self) -> Literal[OutputFormat.XML]:
@@ -86,7 +86,7 @@ class _BaseXmlValidator(BaseValidator, ABC):
             return self.__validator
 
 
-class XmlValidator(_BaseXmlValidator, Validator):
+class XmlValidator(_BaseXmlValidator, SchemaBasedValidator):
     """Validator for CycloneDX documents in XML format."""
 
     @property

--- a/cyclonedx/validation/xml.py
+++ b/cyclonedx/validation/xml.py
@@ -86,7 +86,7 @@ class _BaseXmlValidator(BaseSchemaBasedValidator, ABC):
             return self.__validator
 
 
-class XmlValidator(_BaseXmlValidator, SchemaBasedValidator):
+class XmlValidator(_BaseXmlValidator, BaseSchemaBasedValidator, SchemaBasedValidator):
     """Validator for CycloneDX documents in XML format."""
 
     @property

--- a/examples/complex.py
+++ b/examples/complex.py
@@ -28,7 +28,7 @@ from cyclonedx.output import get_instance as get_outputter
 from cyclonedx.output.json import JsonV1Dot4
 from cyclonedx.schema import SchemaVersion, OutputFormat
 from cyclonedx.validation.json import JsonStrictValidator
-from cyclonedx.validation import get_instance as get_validator
+from cyclonedx.validation.schema import get_instance as get_validator
 
 from typing import TYPE_CHECKING
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -41,8 +41,8 @@ class TestTestGetInstance(TestCase):
         self.assertIs(outputter.schema_version, sv)
 
     @data(
-        *((of, 'foo', (TypeError, "unexpected schema_version: 'foo'")) for of in OutputFormat),
-        *(('foo', sv, (TypeError, "unexpected output_format: 'foo'")) for sv in SchemaVersion),
+        *((of, 'foo', (ValueError, f"Unknown {of.name}/schema_version: 'foo'")) for of in OutputFormat),
+        *(('foo', sv, (ValueError, "Unexpected output_format: 'foo'")) for sv in SchemaVersion),
     )
     @unpack
     def test_fails_on_wrong_args(self, of: OutputFormat, sv: SchemaVersion, raisesRegex: Tuple) -> None:

--- a/tests/test_validation_json.py
+++ b/tests/test_validation_json.py
@@ -48,7 +48,7 @@ class TestJsonValidator(TestCase):
 
     @idata(UNSUPPORTED_SCHEMA_VERSIONS)
     def test_throws_with_unsupported_schema_version(self, schema_version: SchemaVersion) -> None:
-        with self.assertRaisesRegex(ValueError, f'unsupported schema_version: {schema_version}'):
+        with self.assertRaisesRegex(ValueError, 'Unsupported schema_version'):
             JsonValidator(schema_version)
 
     @idata(_dp('valid'))
@@ -82,7 +82,7 @@ class TestJsonStrictValidator(TestCase):
 
     @data(*UNSUPPORTED_SCHEMA_VERSIONS)
     def test_throws_with_unsupported_schema_version(self, schema_version: SchemaVersion) -> None:
-        with self.assertRaisesRegex(ValueError, f'unsupported schema_version: {schema_version}'):
+        with self.assertRaisesRegex(ValueError, 'Unsupported schema_version'):
             JsonStrictValidator(schema_version)
 
     @idata(_dp('valid'))

--- a/tests/test_validation_schema.py
+++ b/tests/test_validation_schema.py
@@ -23,7 +23,7 @@ from unittest import TestCase
 from ddt import data, ddt, named_data, unpack
 
 from cyclonedx.schema import OutputFormat, SchemaVersion
-from cyclonedx.validation import get_instance as get_validator
+from cyclonedx.validation.schema import get_instance as get_validator
 
 UNDEFINED_FORMAT_VERSION = {
     (OutputFormat.JSON, SchemaVersion.V1_1),
@@ -45,8 +45,8 @@ class TestGetInstance(TestCase):
         self.assertIs(validator.schema_version, sv)
 
     @data(
-        *(('foo', sv, (TypeError, "unexpected output_format: 'foo'")) for sv in SchemaVersion),
-        *((f, v, (ValueError, f'unsupported schema_version: {v}')) for f, v in UNDEFINED_FORMAT_VERSION)
+        *(('foo', sv, (ValueError, 'Unexpected output_format')) for sv in SchemaVersion),
+        *((f, v, (ValueError, 'Unsupported schema_version')) for f, v in UNDEFINED_FORMAT_VERSION)
     )
     @unpack
     def test_fails_on_wrong_args(self, of: OutputFormat, sv: SchemaVersion, raisesRegex: Tuple) -> None:


### PR DESCRIPTION
- restructured validators, to enable possible non-schema-based validation. 
- optimized `validation.schema.get_instance()`
- optimized `output.get_instance()`