### PR TITLE
fix: SPDX-expression-validation internal crashes are cought and handled

### DIFF
--- a/cyclonedx/spdx.py
+++ b/cyclonedx/spdx.py
@@ -66,6 +66,9 @@ def is_compound_expression(value: str) -> bool:
     .. _SPDX license expression spec: https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/
     .. _license-expression library: https://github.com/nexB/license-expression
     """
-    return 0 == len(
-        __SPDX_EXPRESSION_LICENSING.validate(value).errors
-    )
+    try:
+        res = __SPDX_EXPRESSION_LICENSING.validate(value)
+    except Exception:
+        # the throw happens when internals crash due to unexpected input characters.
+        return False
+    return 0 == len(res.errors)

--- a/tests/test_spdx.py
+++ b/tests/test_spdx.py
@@ -92,6 +92,7 @@ class TestSpdxIsCompoundExpression(TestCase):
         'MIT AND Apache-2.0 OR something-unknown'
         'something invalid',
         '(c) John Doe',
+        'Apache License, Version 2.0'
     )
     def test_negative(self, invalid_expression: str) -> None:
         actual = spdx.is_compound_expression(invalid_expression)


### PR DESCRIPTION
caused by https://github.com/CycloneDX/cyclonedx-python/issues/598