### PR TITLE
feat: support `py-serializable` v1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,8 +66,8 @@ keywords = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-packageurl-python = ">=0.11"
-py-serializable =  ">=0.16,<0.18"
+packageurl-python = ">=0.11, <2"
+py-serializable =  ">=0.16, <2"
 sortedcontainers = "^2.4.0"
 license-expression = "^30"
 jsonschema = { version = "^4.18", extras=['format'], optional=true }


### PR DESCRIPTION
raised dependency constraint for `py-serializable` to allow v1.0