### PR TITLE
fix: wrong extra name for xml validation

### DIFF
--- a/cyclonedx/validation/xml.py
+++ b/cyclonedx/validation/xml.py
@@ -37,7 +37,7 @@ try:
 except ImportError as err:
     _missing_deps_error = MissingOptionalDependencyException(
         'This functionality requires optional dependencies.\n'
-        'Please install `cyclonedx-python-lib` with the extra "json-validation".\n'
+        'Please install `cyclonedx-python-lib` with the extra "xml-validation".\n'
     ), err
 
 


### PR DESCRIPTION
It would warn about missing xml validation and suggest installing the json-validation extra instead of the xml one.

Fix by suggesting the correct extra.