### PR TITLE
tests: meaningful names to validation tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,8 +16,8 @@
 # Copyright (c) OWASP Foundation. All Rights Reserved.
 import re
 from os import getenv, path
-from os.path import join
-from typing import TYPE_CHECKING, Any, Generator, Iterable, List, Optional, TypeVar, Union
+from os.path import basename, join, splitext
+from typing import TYPE_CHECKING, Any, Generator, Iterable, List, Optional, Tuple, TypeVar, Union
 from unittest import TestCase
 from uuid import UUID
 
@@ -183,3 +183,10 @@ def is_valid_for_schema_version(purpose: Union[Any], sv: SchemaVersion) -> bool:
 
 def mksname(purpose: Union[Any], sv: SchemaVersion, f: OutputFormat) -> str:
     return f'{_get_purpose_as_str(purpose)}-{sv.to_version()}.{_SNAME_EXT[f]}'
+
+
+class DpTuple(Tuple[SchemaVersion, str]):
+    @property
+    def __name__(self) -> str:
+        schema_version, test_data_file = self
+        return f'{schema_version.to_version()}-{splitext(basename(test_data_file))[0]}'

--- a/tests/test_validation_json.py
+++ b/tests/test_validation_json.py
@@ -25,14 +25,14 @@ from ddt import data, ddt, idata, unpack
 from cyclonedx.exception import MissingOptionalDependencyException
 from cyclonedx.schema import OutputFormat, SchemaVersion
 from cyclonedx.validation.json import JsonStrictValidator, JsonValidator
-from tests import SCHEMA_TESTDATA_DIRECTORY
+from tests import SCHEMA_TESTDATA_DIRECTORY, DpTuple
 
 UNSUPPORTED_SCHEMA_VERSIONS = {SchemaVersion.V1_0, SchemaVersion.V1_1, }
 
 
 def _dp(prefix: str) -> Generator:
     return (
-        (sv, tf) for sv in SchemaVersion if sv not in UNSUPPORTED_SCHEMA_VERSIONS
+        DpTuple((sv, tf)) for sv in SchemaVersion if sv not in UNSUPPORTED_SCHEMA_VERSIONS
         for tf in iglob(join(SCHEMA_TESTDATA_DIRECTORY, sv.to_version(), f'{prefix}-*.json'))
     )
 

--- a/tests/test_validation_xml.py
+++ b/tests/test_validation_xml.py
@@ -25,14 +25,14 @@ from ddt import ddt, idata, unpack
 from cyclonedx.exception import MissingOptionalDependencyException
 from cyclonedx.schema import OutputFormat, SchemaVersion
 from cyclonedx.validation.xml import XmlValidator
-from tests import SCHEMA_TESTDATA_DIRECTORY
+from tests import SCHEMA_TESTDATA_DIRECTORY, DpTuple
 
 UNSUPPORTED_SCHEMA_VERSIONS = set()
 
 
 def _dp(prefix: str) -> Generator:
     return (
-        (sv, tf) for sv in SchemaVersion if sv not in UNSUPPORTED_SCHEMA_VERSIONS
+        DpTuple((sv, tf)) for sv in SchemaVersion if sv not in UNSUPPORTED_SCHEMA_VERSIONS
         for tf in iglob(join(SCHEMA_TESTDATA_DIRECTORY, sv.to_version(), f'{prefix}-*.xml'))
     )
 


### PR DESCRIPTION
When packaging cyclonedx-python-lib for a Linux distribution, it’s pretty common that [some JSON validation tests fail](https://aur.archlinux.org/cgit/aur.git/diff/PKGBUILD?h=python-cyclonedx-lib&id=9c6ae556874a633a521407a77a9a85bb31da2047).

Due to the large number of combinations and the fact that these tests are consecutively numbered, it has been tedious to figure out which tests are exactly failing and why.  
This in turn makes it difficult to decide which tests to disable or report upstream.

This PR appends meaningful names to validation tests so that instead of e.g.:

    […]::TestJsonValidator::test_validate_no_none_001
    […]::TestJsonValidator::test_validate_no_none_002
    […]::TestJsonValidator::test_validate_no_none_003
    […]::TestJsonValidator::test_validate_no_none_004
    […]::TestJsonValidator::test_validate_no_none_005
    […]::TestJsonValidator::test_validate_no_none_006
    […]::TestJsonValidator::test_validate_no_none_007
    […]::TestJsonValidator::test_validate_no_none_008

the tests are named:

    […]::TestJsonValidator::test_validate_no_none_001_valid_component_swid_1_6
    […]::TestJsonValidator::test_validate_no_none_002_valid_machine_learning_considerations_env_1_6
    […]::TestJsonValidator::test_validate_no_none_003_valid_metadata_tool_1_6
    […]::TestJsonValidator::test_validate_no_none_004_valid_patch_1_6
    […]::TestJsonValidator::test_validate_no_none_005_valid_empty_components_1_6
    […]::TestJsonValidator::test_validate_no_none_006_valid_properties_1_6
    […]::TestJsonValidator::test_validate_no_none_007_valid_service_1_6
    […]::TestJsonValidator::test_validate_no_none_008_valid_metadata_author_1_6
