### PR TITLE
feat: disjunctive license acknowledgement

### DIFF
--- a/cyclonedx/model/license.py
+++ b/cyclonedx/model/license.py
@@ -34,7 +34,7 @@ from . import AttachedText, XsUri
 
 
 @serializable.serializable_enum
-class LicenseExpressionAcknowledgement(str, Enum):
+class LicenseAcknowledgement(str, Enum):
     """
     This is our internal representation of the `type_licenseAcknowledgementEnumerationType` ENUM type
     within the CycloneDX standard.
@@ -51,6 +51,12 @@ class LicenseExpressionAcknowledgement(str, Enum):
     DECLARED = 'declared'
 
 
+# In an error, the name of the enum was `LicenseExpressionAcknowledgement`.
+# Even though this was changed, there might be some downstream usage of this symbol, so we keep it around ...
+LicenseExpressionAcknowledgement = LicenseAcknowledgement
+"""Deprecated alias for :class:`LicenseAcknowledgement`"""
+
+
 @serializable.serializable_class(name='license')
 class DisjunctiveLicense:
     """
@@ -65,7 +71,7 @@ class DisjunctiveLicense:
         self, *,
         id: Optional[str] = None, name: Optional[str] = None,
         text: Optional[AttachedText] = None, url: Optional[XsUri] = None,
-        acknowledgement: Optional[LicenseExpressionAcknowledgement] = None
+        acknowledgement: Optional[LicenseAcknowledgement] = None
     ) -> None:
         if not id and not name:
             raise MutuallyExclusivePropertiesException('Either `id` or `name` MUST be supplied')
@@ -186,7 +192,7 @@ class DisjunctiveLicense:
     @property
     @serializable.view(SchemaVersion1Dot6)
     @serializable.xml_attribute()
-    def acknowledgement(self) -> Optional[LicenseExpressionAcknowledgement]:
+    def acknowledgement(self) -> Optional[LicenseAcknowledgement]:
         """
         Declared licenses and concluded licenses represent two different stages in the licensing process within
         software development.
@@ -200,12 +206,12 @@ class DisjunctiveLicense:
         in evidence.licenses. Observed licenses form the evidence necessary to substantiate a concluded license.
 
         Returns:
-            `LicenseExpressionAcknowledgement` or `None`
+            `LicenseAcknowledgement` or `None`
         """
         return self._acknowledgement
 
     @acknowledgement.setter
-    def acknowledgement(self, acknowledgement: Optional[LicenseExpressionAcknowledgement]) -> None:
+    def acknowledgement(self, acknowledgement: Optional[LicenseAcknowledgement]) -> None:
         self._acknowledgement = acknowledgement
 
     def __eq__(self, other: object) -> bool:
@@ -244,7 +250,7 @@ class LicenseExpression:
 
     def __init__(
         self, value: str,
-        acknowledgement: Optional[LicenseExpressionAcknowledgement] = None
+        acknowledgement: Optional[LicenseAcknowledgement] = None
     ) -> None:
         self._value = value
         self._acknowledgement = acknowledgement
@@ -278,7 +284,7 @@ class LicenseExpression:
     @property
     @serializable.view(SchemaVersion1Dot6)
     @serializable.xml_attribute()
-    def acknowledgement(self) -> Optional[LicenseExpressionAcknowledgement]:
+    def acknowledgement(self) -> Optional[LicenseAcknowledgement]:
         """
         Declared licenses and concluded licenses represent two different stages in the licensing process within
         software development.
@@ -292,12 +298,12 @@ class LicenseExpression:
         in evidence.licenses. Observed licenses form the evidence necessary to substantiate a concluded license.
 
         Returns:
-            `LicenseExpressionAcknowledgement` or `None`
+            `LicenseAcknowledgement` or `None`
         """
         return self._acknowledgement
 
     @acknowledgement.setter
-    def acknowledgement(self, acknowledgement: Optional[LicenseExpressionAcknowledgement]) -> None:
+    def acknowledgement(self, acknowledgement: Optional[LicenseAcknowledgement]) -> None:
         self._acknowledgement = acknowledgement
 
     def __hash__(self) -> int:

--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -86,7 +86,7 @@ from cyclonedx.model.impact_analysis import (
     ImpactAnalysisState,
 )
 from cyclonedx.model.issue import IssueClassification, IssueType, IssueTypeSource
-from cyclonedx.model.license import DisjunctiveLicense, License, LicenseExpression, LicenseAcknowledgement
+from cyclonedx.model.license import DisjunctiveLicense, License, LicenseAcknowledgement, LicenseExpression
 from cyclonedx.model.release_note import ReleaseNotes
 from cyclonedx.model.service import Service
 from cyclonedx.model.vulnerability import (

--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -86,7 +86,7 @@ from cyclonedx.model.impact_analysis import (
     ImpactAnalysisState,
 )
 from cyclonedx.model.issue import IssueClassification, IssueType, IssueTypeSource
-from cyclonedx.model.license import DisjunctiveLicense, License, LicenseExpression, LicenseExpressionAcknowledgement
+from cyclonedx.model.license import DisjunctiveLicense, License, LicenseExpression, LicenseAcknowledgement
 from cyclonedx.model.release_note import ReleaseNotes
 from cyclonedx.model.service import Service
 from cyclonedx.model.vulnerability import (
@@ -948,11 +948,11 @@ def get_bom_with_licenses() -> Bom:
         components=[
             Component(name='c-with-expression', type=ComponentType.LIBRARY, bom_ref='C1',
                       licenses=[LicenseExpression(value='Apache-2.0 OR MIT',
-                                                  acknowledgement=LicenseExpressionAcknowledgement.CONCLUDED)]),
+                                                  acknowledgement=LicenseAcknowledgement.CONCLUDED)]),
             Component(name='c-with-SPDX', type=ComponentType.LIBRARY, bom_ref='C2',
                       licenses=[DisjunctiveLicense(id='Apache-2.0',
                                                    url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.html'),
-                                                   acknowledgement=LicenseExpressionAcknowledgement.CONCLUDED)]),
+                                                   acknowledgement=LicenseAcknowledgement.CONCLUDED)]),
             Component(name='c-with-name', type=ComponentType.LIBRARY, bom_ref='C3',
                       licenses=[DisjunctiveLicense(name='some commercial license',
                                                    text=AttachedText(content='this is a license text'))]),
@@ -960,11 +960,11 @@ def get_bom_with_licenses() -> Bom:
         services=[
             Service(name='s-with-expression', bom_ref='S1',
                     licenses=[LicenseExpression(value='Apache-2.0 OR MIT',
-                                                acknowledgement=LicenseExpressionAcknowledgement.DECLARED)]),
+                                                acknowledgement=LicenseAcknowledgement.DECLARED)]),
             Service(name='s-with-SPDX', bom_ref='S2',
                     licenses=[DisjunctiveLicense(id='Apache-2.0',
                                                  url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.html'),
-                                                 acknowledgement=LicenseExpressionAcknowledgement.DECLARED)]),
+                                                 acknowledgement=LicenseAcknowledgement.DECLARED)]),
             Service(name='s-with-name', bom_ref='S3',
                     licenses=[DisjunctiveLicense(name='some commercial license',
                                                  text=AttachedText(content='this is a license text'))]),

--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -950,18 +950,24 @@ def get_bom_with_licenses() -> Bom:
                       licenses=[LicenseExpression(value='Apache-2.0 OR MIT',
                                                   acknowledgement=LicenseExpressionAcknowledgement.CONCLUDED)]),
             Component(name='c-with-SPDX', type=ComponentType.LIBRARY, bom_ref='C2',
-                      licenses=[DisjunctiveLicense(id='Apache-2.0')]),
+                      licenses=[DisjunctiveLicense(id='Apache-2.0',
+                                                   url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.html'),
+                                                   acknowledgement=LicenseExpressionAcknowledgement.CONCLUDED)]),
             Component(name='c-with-name', type=ComponentType.LIBRARY, bom_ref='C3',
-                      licenses=[DisjunctiveLicense(name='(c) ACME Inc.')]),
+                      licenses=[DisjunctiveLicense(name='some commercial license',
+                                                   text=AttachedText(content='this is a license text'))]),
         ],
         services=[
             Service(name='s-with-expression', bom_ref='S1',
                     licenses=[LicenseExpression(value='Apache-2.0 OR MIT',
                                                 acknowledgement=LicenseExpressionAcknowledgement.DECLARED)]),
             Service(name='s-with-SPDX', bom_ref='S2',
-                    licenses=[DisjunctiveLicense(id='Apache-2.0')]),
+                    licenses=[DisjunctiveLicense(id='Apache-2.0',
+                                                 url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.html'),
+                                                 acknowledgement=LicenseExpressionAcknowledgement.DECLARED)]),
             Service(name='s-with-name', bom_ref='S3',
-                    licenses=[DisjunctiveLicense(name='(c) ACME Inc.')]),
+                    licenses=[DisjunctiveLicense(name='some commercial license',
+                                                 text=AttachedText(content='this is a license text'))]),
         ])
 
 

--- a/tests/_data/snapshots/get_bom_with_licenses-1.1.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.1.xml.bin
@@ -7,6 +7,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </component>
@@ -22,7 +23,8 @@
       <version/>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </component>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.2.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.2.json.bin
@@ -5,7 +5,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -29,7 +30,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],
@@ -91,7 +96,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -111,7 +117,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],

--- a/tests/_data/snapshots/get_bom_with_licenses-1.2.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.2.xml.bin
@@ -26,6 +26,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </component>
@@ -41,7 +42,8 @@
       <version/>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </component>
@@ -52,6 +54,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </service>
@@ -65,7 +68,8 @@
       <name>s-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </service>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.3.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.3.json.bin
@@ -5,7 +5,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -29,7 +30,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],
@@ -98,7 +103,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -118,7 +124,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],

--- a/tests/_data/snapshots/get_bom_with_licenses-1.3.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.3.xml.bin
@@ -31,6 +31,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </component>
@@ -46,7 +47,8 @@
       <version/>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </component>
@@ -57,6 +59,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </service>
@@ -70,7 +73,8 @@
       <name>s-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </service>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.4.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.4.json.bin
@@ -5,7 +5,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -27,7 +28,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],
@@ -128,7 +133,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -148,7 +154,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],

--- a/tests/_data/snapshots/get_bom_with_licenses-1.4.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.4.xml.bin
@@ -55,6 +55,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </component>
@@ -68,7 +69,8 @@
       <name>c-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </component>
@@ -79,6 +81,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </service>
@@ -92,7 +95,8 @@
       <name>s-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </service>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.5.json.bin
@@ -5,7 +5,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -27,7 +28,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],
@@ -138,7 +143,8 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -158,7 +164,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],

--- a/tests/_data/snapshots/get_bom_with_licenses-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.5.xml.bin
@@ -55,6 +55,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </component>
@@ -68,7 +69,8 @@
       <name>c-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </component>
@@ -79,6 +81,7 @@
       <licenses>
         <license>
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </service>
@@ -92,7 +95,8 @@
       <name>s-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </service>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.6.json.bin
@@ -5,7 +5,9 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "acknowledgement": "concluded",
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -28,7 +30,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],
@@ -139,7 +145,9 @@
       "licenses": [
         {
           "license": {
-            "id": "Apache-2.0"
+            "acknowledgement": "declared",
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
         }
       ],
@@ -160,7 +168,11 @@
       "licenses": [
         {
           "license": {
-            "name": "(c) ACME Inc."
+            "name": "some commercial license",
+            "text": {
+              "content": "this is a license text",
+              "contentType": "text/plain"
+            }
           }
         }
       ],

--- a/tests/_data/snapshots/get_bom_with_licenses-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.6.xml.bin
@@ -53,8 +53,9 @@
     <component type="library" bom-ref="C2">
       <name>c-with-SPDX</name>
       <licenses>
-        <license>
+        <license acknowledgement="concluded">
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </component>
@@ -68,7 +69,8 @@
       <name>c-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </component>
@@ -77,8 +79,9 @@
     <service bom-ref="S2">
       <name>s-with-SPDX</name>
       <licenses>
-        <license>
+        <license acknowledgement="declared">
           <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
       </licenses>
     </service>
@@ -92,7 +95,8 @@
       <name>s-with-name</name>
       <licenses>
         <license>
-          <name>(c) ACME Inc.</name>
+          <name>some commercial license</name>
+          <text content-type="text/plain">this is a license text</text>
         </license>
       </licenses>
     </service>


### PR DESCRIPTION
fixes #590

- renamed class `LicenseExpressionAcknowledgement` to `LicenseAcknowledgement`
- added _deprecated_ alias `LicenseExpressionAcknowledgement` for `LicenseAcknowledgement`  
  so there is no breaking change
- added property `DisjunctiveLicense.acknowledgement`
- added integration test for new properties and structures