### PR TITLE
refactor!: `LicenseExpression()` optional args are named args

### DIFF
--- a/cyclonedx/model/license.py
+++ b/cyclonedx/model/license.py
@@ -250,7 +250,7 @@ class LicenseExpression:
     """
 
     def __init__(
-        self, value: str,  # *,  # all optional args are intended to be keyword-args
+        self, value: str, *,
         acknowledgement: Optional[LicenseAcknowledgement] = None,
     ) -> None:
         self._value = value


### PR DESCRIPTION
fixes #594