### PR TITLE
fix: `cyclonedx.model.Property.value` value is optional

### DIFF
--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -845,7 +845,7 @@ class Property:
     Specifies an individual property with a name and value.
     """
 
-    def __init__(self, *, name: str, value: str) -> None:
+    def __init__(self, *, name: str, value: Optional[str] = None) -> None:
         self.name = name
         self.value = value
 
@@ -868,7 +868,7 @@ class Property:
 
     @property
     @serializable.xml_name('.')
-    def value(self) -> str:
+    def value(self) -> Optional[str]:
         """
         Value of this Property.
 
@@ -878,7 +878,7 @@ class Property:
         return self._value
 
     @value.setter
-    def value(self, value: str) -> None:
+    def value(self, value: Optional[str]) -> None:
         self._value = value
 
     def __eq__(self, other: object) -> bool:

--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -1108,6 +1108,20 @@ def bom_all_same_bomref() -> Tuple[Bom, int]:
     return bom, nr_bomrefs
 
 
+def get_bom_for_issue_630_empty_property() -> Bom:
+    """regression test for issue #630
+    see https://github.com/CycloneDX/cyclonedx-python-lib/issues/630
+    """
+    return _make_bom(components={
+        Component(
+            bom_ref='example@15.8.0',
+            type=ComponentType.LIBRARY,
+            name='example',
+            version='15.8.0',
+            properties=[Property(name='cdx:npm:package:path')]
+        )
+    })
+
 # ---
 
 
@@ -1147,4 +1161,5 @@ all_get_bom_funct_with_incomplete_deps = {
     get_bom_for_issue_497_urls,
     get_bom_for_issue_598_multiple_components_with_purl_qualifiers,
     get_bom_with_component_setuptools_with_v16_fields,
+    get_bom_for_issue_630_empty_property,
 }

--- a/tests/_data/own/xml/1.6/regression_issue630.xml
+++ b/tests/_data/own/xml/1.6/regression_issue630.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6">
+    <components>
+        <component type="library" bom-ref="example@15.8.0">
+            <name>example</name>
+            <version>15.8.0</version>
+            <properties>
+                <property name="cdx:npm:package:path" />
+            </properties>
+        </component>
+    </components>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.0.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.0.xml.bin
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.0" version="1">
+  <components>
+    <component type="library">
+      <name>example</name>
+      <version>15.8.0</version>
+      <modified>false</modified>
+    </component>
+  </components>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.1.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.1.xml.bin
@@ -1,0 +1,9 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.1" serialNumber="urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac" version="1">
+  <components>
+    <component type="library" bom-ref="example@15.8.0">
+      <name>example</name>
+      <version>15.8.0</version>
+    </component>
+  </components>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.2.json.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.2.json.bin
@@ -1,0 +1,30 @@
+{
+  "components": [
+    {
+      "bom-ref": "example@15.8.0",
+      "name": "example",
+      "type": "library",
+      "version": "15.8.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "example@15.8.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2023-01-07T13:44:32.312678+00:00",
+    "tools": [
+      {
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "TESTING"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.2b.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.2"
+}

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.2.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.2.xml.bin
@@ -1,0 +1,22 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.2" serialNumber="urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac" version="1">
+  <metadata>
+    <timestamp>2023-01-07T13:44:32.312678+00:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>TESTING</version>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="example@15.8.0">
+      <name>example</name>
+      <version>15.8.0</version>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="example@15.8.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.3.json.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.3.json.bin
@@ -1,0 +1,35 @@
+{
+  "components": [
+    {
+      "bom-ref": "example@15.8.0",
+      "name": "example",
+      "properties": [
+        {
+          "name": "cdx:npm:package:path"
+        }
+      ],
+      "type": "library",
+      "version": "15.8.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "example@15.8.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2023-01-07T13:44:32.312678+00:00",
+    "tools": [
+      {
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "TESTING"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.3a.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.3"
+}

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.3.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.3.xml.bin
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.3" serialNumber="urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac" version="1">
+  <metadata>
+    <timestamp>2023-01-07T13:44:32.312678+00:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>TESTING</version>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="example@15.8.0">
+      <name>example</name>
+      <version>15.8.0</version>
+      <properties>
+        <property name="cdx:npm:package:path"/>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="example@15.8.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.4.json.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.4.json.bin
@@ -1,0 +1,69 @@
+{
+  "components": [
+    {
+      "bom-ref": "example@15.8.0",
+      "name": "example",
+      "properties": [
+        {
+          "name": "cdx:npm:package:path"
+        }
+      ],
+      "type": "library",
+      "version": "15.8.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "example@15.8.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2023-01-07T13:44:32.312678+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "TESTING"
+      }
+    ]
+  },
+  "serialNumber": "urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4"
+}

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.4.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.4.xml.bin
@@ -1,0 +1,51 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.4" serialNumber="urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac" version="1">
+  <metadata>
+    <timestamp>2023-01-07T13:44:32.312678+00:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>TESTING</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-python-lib/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-python-library.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="example@15.8.0">
+      <name>example</name>
+      <version>15.8.0</version>
+      <properties>
+        <property name="cdx:npm:package:path"/>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="example@15.8.0"/>
+  </dependencies>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.5.json.bin
@@ -1,0 +1,79 @@
+{
+  "components": [
+    {
+      "bom-ref": "example@15.8.0",
+      "name": "example",
+      "properties": [
+        {
+          "name": "cdx:npm:package:path"
+        }
+      ],
+      "type": "library",
+      "version": "15.8.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "example@15.8.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2023-01-07T13:44:32.312678+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "TESTING"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "name": "key1",
+      "value": "val1"
+    },
+    {
+      "name": "key2",
+      "value": "val2"
+    }
+  ],
+  "serialNumber": "urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5"
+}

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.5.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.5" serialNumber="urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac" version="1">
+  <metadata>
+    <timestamp>2023-01-07T13:44:32.312678+00:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>TESTING</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-python-lib/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-python-library.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="example@15.8.0">
+      <name>example</name>
+      <version>15.8.0</version>
+      <properties>
+        <property name="cdx:npm:package:path"/>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="example@15.8.0"/>
+  </dependencies>
+  <properties>
+    <property name="key1">val1</property>
+    <property name="key2">val2</property>
+  </properties>
+</bom>

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.6.json.bin
@@ -1,0 +1,79 @@
+{
+  "components": [
+    {
+      "bom-ref": "example@15.8.0",
+      "name": "example",
+      "properties": [
+        {
+          "name": "cdx:npm:package:path"
+        }
+      ],
+      "type": "library",
+      "version": "15.8.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "example@15.8.0"
+    }
+  ],
+  "metadata": {
+    "timestamp": "2023-01-07T13:44:32.312678+00:00",
+    "tools": [
+      {
+        "externalReferences": [
+          {
+            "type": "build-system",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
+          },
+          {
+            "type": "distribution",
+            "url": "https://pypi.org/project/cyclonedx-python-lib/"
+          },
+          {
+            "type": "documentation",
+            "url": "https://cyclonedx-python-library.readthedocs.io/"
+          },
+          {
+            "type": "issue-tracker",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
+          },
+          {
+            "type": "license",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
+          },
+          {
+            "type": "release-notes",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
+          },
+          {
+            "type": "vcs",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
+          },
+          {
+            "type": "website",
+            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
+          }
+        ],
+        "name": "cyclonedx-python-lib",
+        "vendor": "CycloneDX",
+        "version": "TESTING"
+      }
+    ]
+  },
+  "properties": [
+    {
+      "name": "key1",
+      "value": "val1"
+    },
+    {
+      "name": "key2",
+      "value": "val2"
+    }
+  ],
+  "serialNumber": "urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac",
+  "version": 1,
+  "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6"
+}

--- a/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_for_issue_630_empty_property-1.6.xml.bin
@@ -1,0 +1,55 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6" serialNumber="urn:uuid:1441d33a-e0fc-45b5-af3b-61ee52a88bac" version="1">
+  <metadata>
+    <timestamp>2023-01-07T13:44:32.312678+00:00</timestamp>
+    <tools>
+      <tool>
+        <vendor>CycloneDX</vendor>
+        <name>cyclonedx-python-lib</name>
+        <version>TESTING</version>
+        <externalReferences>
+          <reference type="build-system">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/actions</url>
+          </reference>
+          <reference type="distribution">
+            <url>https://pypi.org/project/cyclonedx-python-lib/</url>
+          </reference>
+          <reference type="documentation">
+            <url>https://cyclonedx-python-library.readthedocs.io/</url>
+          </reference>
+          <reference type="issue-tracker">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/issues</url>
+          </reference>
+          <reference type="license">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE</url>
+          </reference>
+          <reference type="release-notes">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md</url>
+          </reference>
+          <reference type="vcs">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib</url>
+          </reference>
+          <reference type="website">
+            <url>https://github.com/CycloneDX/cyclonedx-python-lib/#readme</url>
+          </reference>
+        </externalReferences>
+      </tool>
+    </tools>
+  </metadata>
+  <components>
+    <component type="library" bom-ref="example@15.8.0">
+      <name>example</name>
+      <version>15.8.0</version>
+      <properties>
+        <property name="cdx:npm:package:path"/>
+      </properties>
+    </component>
+  </components>
+  <dependencies>
+    <dependency ref="example@15.8.0"/>
+  </dependencies>
+  <properties>
+    <property name="key1">val1</property>
+    <property name="key2">val2</property>
+  </properties>
+</bom>

--- a/tests/test_real_world_examples.py
+++ b/tests/test_real_world_examples.py
@@ -27,8 +27,12 @@ from tests import OWN_DATA_DIRECTORY
 
 @patch('cyclonedx.model.ThisTool._version', 'TESTING')
 @patch('cyclonedx.model.bom._get_now_utc', return_value=datetime.fromisoformat('2023-01-07 13:44:32.312678+00:00'))
-class TestDeserializeeRealWorldExamples(unittest.TestCase):
+class TestDeserializeRealWorldExamples(unittest.TestCase):
 
     def test_webgoat_6_1(self, *_: Any, **__: Any) -> None:
         with open(join(OWN_DATA_DIRECTORY, 'xml', '1.4', 'webgoat-6.1.xml')) as input_xml:
+            Bom.from_xml(input_xml)
+
+    def test_regression_issue_630(self, *_: Any, **__: Any) -> None:
+        with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue630.xml')) as input_xml:
             Bom.from_xml(input_xml)


### PR DESCRIPTION
`cyclonedx.model.Property.value` value is optional, in accordance with the spec.

fixes #630

