### PR TITLE
feat: add workaround property for v1.5 and v1.6

### DIFF
--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -908,9 +908,9 @@ class Vulnerability:
                  references: Optional[Iterable[VulnerabilityReference]] = None,
                  ratings: Optional[Iterable[VulnerabilityRating]] = None, cwes: Optional[Iterable[int]] = None,
                  description: Optional[str] = None, detail: Optional[str] = None, recommendation: Optional[str] = None,
-                 advisories: Optional[Iterable[VulnerabilityAdvisory]] = None, created: Optional[datetime] = None,
-                 published: Optional[datetime] = None, updated: Optional[datetime] = None,
-                 credits: Optional[VulnerabilityCredits] = None,
+                 workaround: Optional[str] = None, advisories: Optional[Iterable[VulnerabilityAdvisory]] = None,
+                 created: Optional[datetime] = None, published: Optional[datetime] = None,
+                 updated: Optional[datetime] = None, credits: Optional[VulnerabilityCredits] = None,
                  tools: Optional[Iterable[Tool]] = None, analysis: Optional[VulnerabilityAnalysis] = None,
                  affects: Optional[Iterable[BomTarget]] = None,
                  properties: Optional[Iterable[Property]] = None
@@ -927,6 +927,7 @@ class Vulnerability:
         self.description = description
         self.detail = detail
         self.recommendation = recommendation
+        self.workaround = workaround
         self.advisories = advisories or []  # type:ignore[assignment]
         self.created = created
         self.published = published
@@ -1083,15 +1084,23 @@ class Vulnerability:
     def recommendation(self, recommendation: Optional[str]) -> None:
         self._recommendation = recommendation
 
-    # @property
-    # @serializable.view(SchemaVersion1Dot5)
-    # @serializable.xml_sequence(9)
-    # def workaround(self) -> ...:
-    #     ...  # TODO since CDX 1.5
-    #
-    # @workaround.setter
-    # def workaround(self, ...) -> None:
-    #     ...  # TODO since CDX 1.5
+    @property
+    @serializable.view(SchemaVersion1Dot5)
+    @serializable.view(SchemaVersion1Dot6)
+    @serializable.xml_sequence(9)
+    def workaround(self) -> Optional[str]:
+        """
+        A bypass, usually temporary, of the vulnerability that reduces its likelihood and/or impact.
+        Workarounds often involve changes to configuration or deployments.
+
+        Returns:
+            `str` if set else `None`
+        """
+        return self._workaround
+
+    @workaround.setter
+    def workaround(self, workaround: Optional[str]) -> None:
+        self._workaround = workaround
 
     # @property
     # @serializable.view(SchemaVersion1Dot5)
@@ -1273,8 +1282,8 @@ class Vulnerability:
     def __hash__(self) -> int:
         return hash((
             self.id, self.source, tuple(self.references), tuple(self.ratings), tuple(self.cwes), self.description,
-            self.detail, self.recommendation, tuple(self.advisories), self.created, self.published, self.updated,
-            self.credits, tuple(self.tools), self.analysis, tuple(self.affects), tuple(self.properties)
+            self.detail, self.recommendation, self.workaround, tuple(self.advisories), self.created, self.published,
+            self.updated, self.credits, tuple(self.tools), self.analysis, tuple(self.affects), tuple(self.properties)
         ))
 
     def __repr__(self) -> str:

--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -477,7 +477,7 @@ def get_bom_with_component_setuptools_with_vulnerability() -> Bom:
             )
         ],
         cwes=[22, 33], description='A description here', detail='Some detail here',
-        recommendation='Upgrade',
+        recommendation='Upgrade', workaround='Describe the workarounds here',
         advisories=[
             VulnerabilityAdvisory(url=XsUri('https://nvd.nist.gov/vuln/detail/CVE-2018-7489')),
             VulnerabilityAdvisory(url=XsUri('http://www.securitytracker.com/id/1040693'))

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.json.bin
@@ -199,7 +199,8 @@
           "vendor": "CycloneDX"
         }
       ],
-      "updated": "2021-09-03T10:50:42.051979+00:00"
+      "updated": "2021-09-03T10:50:42.051979+00:00",
+      "workaround": "Describe the workarounds here"
     }
   ],
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.xml.bin
@@ -103,6 +103,7 @@
       <description>A description here</description>
       <detail>Some detail here</detail>
       <recommendation>Upgrade</recommendation>
+      <workaround>Describe the workarounds here</workaround>
       <advisories>
         <advisory>
           <url>http://www.securitytracker.com/id/1040693</url>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.json.bin
@@ -205,7 +205,8 @@
           "vendor": "CycloneDX"
         }
       ],
-      "updated": "2021-09-03T10:50:42.051979+00:00"
+      "updated": "2021-09-03T10:50:42.051979+00:00",
+      "workaround": "Describe the workarounds here"
     }
   ],
   "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.xml.bin
@@ -103,6 +103,7 @@
       <description>A description here</description>
       <detail>Some detail here</detail>
       <recommendation>Upgrade</recommendation>
+      <workaround>Describe the workarounds here</workaround>
       <advisories>
         <advisory>
           <url>http://www.securitytracker.com/id/1040693</url>

--- a/tests/test_model_vulnerability.py
+++ b/tests/test_model_vulnerability.py
@@ -171,6 +171,7 @@ class TestModelVulnerability(TestCase):
         self.assertIsNone(v.description)
         self.assertIsNone(v.detail)
         self.assertIsNone(v.recommendation)
+        self.assertIsNone(v.workaround)
         self.assertFalse(v.advisories)
         self.assertIsNone(v.created)
         self.assertIsNone(v.published)


### PR DESCRIPTION
Property `workaround` was missing from the vulnerability model. It was added in spec v1.5 and was marked as TODO before.

This is my first contribution on this project so if I done something wrong, just say me :smiley: 