### PR TITLE
fix: no warning for missing dependencies if no component exists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: system
         name: mypy
-        entry: poetry run tox -e mypy-locked
+        entry: poetry run tox -e mypy-current
         pass_filenames: false
         language: system
   - repo: local

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -675,8 +675,9 @@ class Bom:
                 'One or more Components have Dependency references to Components/Services that are not known in this '
                 f'BOM. They are: {dependency_diff}')
 
-        # 2. if root component is set: dependencies should exist for the Component this BOM is describing
-        if self.metadata.component and not any(map(
+        # 2. if root component is set and there are other components: dependencies should exist for the Component
+        # this BOM is describing
+        if self.metadata.component and len(self.components) > 0 and not any(map(
             lambda d: d.ref == self.metadata.component.bom_ref and len(d.dependencies) > 0,  # type: ignore[union-attr]
             self.dependencies
         )):

--- a/tests/test_model_bom.py
+++ b/tests/test_model_bom.py
@@ -14,8 +14,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # Copyright (c) OWASP Foundation. All Rights Reserved.
-
-
+import warnings
 from typing import Callable, Tuple
 from unittest import TestCase
 from uuid import uuid4
@@ -31,6 +30,7 @@ from cyclonedx.model.contact import OrganizationalContact, OrganizationalEntity
 from cyclonedx.model.license import DisjunctiveLicense
 from cyclonedx.model.lifecycle import LifecyclePhase, NamedLifecycle, PredefinedLifecycle
 from cyclonedx.model.tool import Tool
+from cyclonedx.output.json import JsonV1Dot6
 from tests._data.models import (
     get_bom_component_licenses_invalid,
     get_bom_component_nested_licenses_invalid,
@@ -138,6 +138,15 @@ class TestBom(TestCase):
         self.assertFalse(bom.components)
         self.assertFalse(bom.services)
         self.assertFalse(bom.external_references)
+
+    def test_root_component_only_bom(self) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', UserWarning)  # Turn UserWarnings into errors
+            try:
+                bom = Bom(metadata=BomMetaData(component=Component(name='test', version='1.2')))
+                _ = JsonV1Dot6(bom).output_as_string()
+            except UserWarning as e:
+                self.fail(f"A warning with 'warn' was issued: {e}")
 
     def test_empty_bom_defined_serial(self) -> None:
         serial_number = uuid4()


### PR DESCRIPTION
Adds a condition to check if the root component is the only component and then doesn't issue the warning. Closes #617 