### PR TITLE
docs: remove invalid docsting note about auto-assigned `bom-ref` values

### DIFF
--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -1185,8 +1185,6 @@ class Component(Dependable):
         An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be
         unique within the BOM.
 
-        If a value was not provided in the constructor, a UUIDv4 will have been assigned.
-
         Returns:
             `BomRef`
         """

--- a/cyclonedx/model/contact.py
+++ b/cyclonedx/model/contact.py
@@ -68,8 +68,6 @@ class PostalAddress:
         An optional identifier which can be used to reference the component elsewhere in the BOM. Every bom-ref MUST be
         unique within the BOM.
 
-        If a value was not provided in the constructor, a UUIDv4 will have been assigned.
-
         Returns:
             `BomRef`
         """

--- a/cyclonedx/model/definition.py
+++ b/cyclonedx/model/definition.py
@@ -81,7 +81,8 @@ class Standard:
     def bom_ref(self) -> BomRef:
         """
         An optional identifier which can be used to reference the standard elsewhere in the BOM. Every bom-ref MUST be
-        unique within the BOM. If a value was not provided in the constructor, a UUIDv4 will have been assigned.
+        unique within the BOM.
+
         Returns:
             `BomRef`
         """

--- a/cyclonedx/model/service.py
+++ b/cyclonedx/model/service.py
@@ -95,8 +95,6 @@ class Service(Dependable):
         An optional identifier which can be used to reference the service elsewhere in the BOM. Uniqueness is enforced
         within all elements and children of the root-level bom element.
 
-        If a value was not provided in the constructor, a UUIDv4 will have been assigned.
-
         Returns:
            `BomRef` unique identifier for this Service
         """

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -989,8 +989,6 @@ class Vulnerability:
         """
         Get the unique reference for this Vulnerability in this BOM.
 
-        If a value was not provided in the constructor, a UUIDv4 will have been assigned.
-
         Returns:
            `BomRef`
         """


### PR DESCRIPTION
the auto-assigning `UUITv4` was removed in a breaking change in v6.0.0 . 

> * Object `model.bom_ref.BomRef`&#39;s property `value` defaults to `Null`, was arbitrary `UUID` ([#504] via [#505])

this fix aligns the docs.

