### PR TITLE
feat: allow empty `OrganizationalEntity` object

### DIFF
--- a/cyclonedx/model/contact.py
+++ b/cyclonedx/model/contact.py
@@ -296,10 +296,6 @@ class OrganizationalEntity:
         contacts: Optional[Iterable[OrganizationalContact]] = None,
         address: Optional[PostalAddress] = None,
     ) -> None:
-        if name is None and not urls and not contacts:
-            raise NoPropertiesProvidedException(
-                'One of name, urls or contacts must be supplied for an OrganizationalEntity - none supplied.'
-            )
         self.name = name
         self.address = address
         self.urls = urls or []  # type:ignore[assignment]

--- a/tests/_data/own/json/1.6/issue764.json
+++ b/tests/_data/own/json/1.6/issue764.json
@@ -1,0 +1,26 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2025-01-25T19:11:26Z",
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:maven/foo/bar@1.2.3",
+      "name" : "foo-bar",
+      "version" : "1.2.3",
+      "purl" : "pkg:maven/foo/bar@1.2.3",
+      "modified" : false
+    },
+    "manufacture" : { },
+    "licenses" : [ ]
+  },
+  "components" : [
+    {
+      "type" : "library",
+      "name": "some-lib",
+      "manufacturer" : { }
+    }
+  ],
+  "dependencies" : [ ]
+}

--- a/tests/test_deserialize_json.py
+++ b/tests/test_deserialize_json.py
@@ -88,6 +88,19 @@ class TestDeserializeJson(TestCase, SnapshotMixin, DeepCompareMixin):
         test(list(bom.components)[0].licenses)
         test(list(bom.services)[0].licenses)
 
+    def test_regression_issue764(self) -> None:
+        """
+        regression test for issue#764.
+        see https://github.com/CycloneDX/cyclonedx-python-lib/issues/764
+        """
+        json_file = join(OWN_DATA_DIRECTORY, 'json',
+                         SchemaVersion.V1_6.to_version(),
+                         'issue764.json')
+        with open(json_file) as f:
+            json = json_loads(f.read())
+        bom: Bom = Bom.from_json(json)  # <<< is expected to not crash
+        self.assertIsNotNone(bom)
+
     def test_regression_issue690(self) -> None:
         """
         regressio test for issue#690.


### PR DESCRIPTION
fixes https://github.com/CycloneDX/cyclonedx-python-lib/issues/764