### PR TITLE
feat: allow empty `OrganizationalContact` object

### DIFF
--- a/cyclonedx/model/contact.py
+++ b/cyclonedx/model/contact.py
@@ -202,10 +202,6 @@ class OrganizationalContact:
         phone: Optional[str] = None,
         email: Optional[str] = None,
     ) -> None:
-        if not name and not phone and not email:
-            raise NoPropertiesProvidedException(
-                'One of name, email or phone must be supplied for an OrganizationalContact - none supplied.'
-            )
         self.name = name
         self.email = email
         self.phone = phone

--- a/cyclonedx/model/contact.py
+++ b/cyclonedx/model/contact.py
@@ -23,7 +23,6 @@ from sortedcontainers import SortedSet
 
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str
 from .._internal.compare import ComparableTuple as _ComparableTuple
-from ..exception.model import NoPropertiesProvidedException
 from ..schema.schema import SchemaVersion1Dot6
 from . import XsUri
 from .bom_ref import BomRef

--- a/tests/_data/own/json/1.6/issue771.json
+++ b/tests/_data/own/json/1.6/issue771.json
@@ -1,0 +1,21 @@
+{
+  "bomFormat" : "CycloneDX",
+  "specVersion" : "1.6",
+  "version" : 1,
+  "metadata" : {
+    "timestamp" : "2025-01-25T19:11:26Z",
+    "component" : {
+      "type" : "application",
+      "bom-ref" : "pkg:maven/foo/bar@1.2.3",
+      "name" : "foo-bar",
+      "supplier": {
+        "name": "foo",
+        "contact": [
+          {}
+        ]
+      }
+    }
+  },
+  "components" : [ ],
+  "dependencies" : [ ]
+}

--- a/tests/test_deserialize_json.py
+++ b/tests/test_deserialize_json.py
@@ -88,6 +88,19 @@ class TestDeserializeJson(TestCase, SnapshotMixin, DeepCompareMixin):
         test(list(bom.components)[0].licenses)
         test(list(bom.services)[0].licenses)
 
+    def test_regression_issue771(self) -> None:
+        """
+        regression test for issue#771.
+        see https://github.com/CycloneDX/cyclonedx-python-lib/issues/771
+        """
+        json_file = join(OWN_DATA_DIRECTORY, 'json',
+                         SchemaVersion.V1_6.to_version(),
+                         'issue771.json')
+        with open(json_file) as f:
+            json = json_loads(f.read())
+        bom: Bom = Bom.from_json(json)  # <<< is expected to not crash
+        self.assertIsNotNone(bom)
+
     def test_regression_issue764(self) -> None:
         """
         regression test for issue#764.


### PR DESCRIPTION
fixes https://github.com/CycloneDX/cyclonedx-python-lib/issues/771