### PR TITLE
chore(deps)!: `py-serializable==^1.1.1` -> `^2.0.0`

### DIFF
--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -33,7 +33,7 @@ from uuid import UUID
 from warnings import warn
 from xml.etree.ElementTree import Element as XmlElement  # nosec B405
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -22,7 +22,7 @@ from typing import TYPE_CHECKING, Generator, Iterable, Optional, Union
 from uuid import UUID, uuid4
 from warnings import warn
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.time import get_now_utc as _get_now_utc

--- a/cyclonedx/model/bom_ref.py
+++ b/cyclonedx/model/bom_ref.py
@@ -18,7 +18,7 @@
 
 from typing import TYPE_CHECKING, Any, Optional
 
-import serializable
+import py_serializable as serializable
 
 from ..exception.serialization import CycloneDxDeserializationException, SerializationOfUnexpectedValueException
 

--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, FrozenSet, Iterable, Optional, Set, Type, Union
 from warnings import warn
 
 # See https://github.com/package-url/packageurl-python/issues/65
-import serializable
+import py_serializable as serializable
 from packageurl import PackageURL
 from sortedcontainers import SortedSet
 

--- a/cyclonedx/model/contact.py
+++ b/cyclonedx/model/contact.py
@@ -18,7 +18,7 @@
 
 from typing import Any, Iterable, Optional, Union
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str

--- a/cyclonedx/model/crypto.py
+++ b/cyclonedx/model/crypto.py
@@ -29,7 +29,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Iterable, Optional
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple

--- a/cyclonedx/model/definition.py
+++ b/cyclonedx/model/definition.py
@@ -18,7 +18,7 @@
 import re
 from typing import TYPE_CHECKING, Any, Iterable, Optional, Union
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str

--- a/cyclonedx/model/dependency.py
+++ b/cyclonedx/model/dependency.py
@@ -19,7 +19,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Iterable, List, Optional, Set
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple

--- a/cyclonedx/model/impact_analysis.py
+++ b/cyclonedx/model/impact_analysis.py
@@ -28,7 +28,7 @@ Impact Analysis is new for CycloneDX schema version 1.
 
 from enum import Enum
 
-import serializable
+import py_serializable as serializable
 
 
 @serializable.serializable_enum

--- a/cyclonedx/model/issue.py
+++ b/cyclonedx/model/issue.py
@@ -18,7 +18,7 @@
 from enum import Enum
 from typing import Any, Iterable, Optional
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple

--- a/cyclonedx/model/license.py
+++ b/cyclonedx/model/license.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 from warnings import warn
 from xml.etree.ElementTree import Element  # nosec B405
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple

--- a/cyclonedx/model/lifecycle.py
+++ b/cyclonedx/model/lifecycle.py
@@ -30,15 +30,15 @@ from json import loads as json_loads
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, Union
 from xml.etree.ElementTree import Element  # nosec B405
 
-import serializable
-from serializable.helpers import BaseHelper
+import py_serializable as serializable
+from py_serializable.helpers import BaseHelper
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple
 from ..exception.serialization import CycloneDxDeserializationException
 
 if TYPE_CHECKING:  # pragma: no cover
-    from serializable import ViewType
+    from py_serializable import ViewType
 
 
 @serializable.serializable_enum

--- a/cyclonedx/model/release_note.py
+++ b/cyclonedx/model/release_note.py
@@ -18,7 +18,7 @@
 from datetime import datetime
 from typing import Iterable, Optional
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from ..model import Note, Property, XsUri

--- a/cyclonedx/model/service.py
+++ b/cyclonedx/model/service.py
@@ -26,7 +26,7 @@ This set of classes represents the data that is possible about known Services.
 
 from typing import Any, Iterable, Optional, Union
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str

--- a/cyclonedx/model/tool.py
+++ b/cyclonedx/model/tool.py
@@ -21,8 +21,8 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Type, Uni
 from warnings import warn
 from xml.etree.ElementTree import Element  # nosec B405
 
-import serializable
-from serializable.helpers import BaseHelper
+import py_serializable as serializable
+from py_serializable.helpers import BaseHelper
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple
@@ -33,7 +33,7 @@ from .component import Component
 from .service import Service
 
 if TYPE_CHECKING:  # pragma: no cover
-    from serializable import ObjectMetadataLibrary, ViewType
+    from py_serializable import ObjectMetadataLibrary, ViewType
 
 
 @serializable.serializable_class

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -35,7 +35,7 @@ from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, FrozenSet, Iterable, Optional, Tuple, Type, Union
 
-import serializable
+import py_serializable as serializable
 from sortedcontainers import SortedSet
 
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str

--- a/cyclonedx/schema/schema.py
+++ b/cyclonedx/schema/schema.py
@@ -18,7 +18,7 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Literal, Type
 
-from serializable import ViewType
+from py_serializable import ViewType
 
 from . import SchemaVersion
 

--- a/cyclonedx/serialization/__init__.py
+++ b/cyclonedx/serialization/__init__.py
@@ -25,7 +25,7 @@ from uuid import UUID
 
 # See https://github.com/package-url/packageurl-python/issues/65
 from packageurl import PackageURL
-from serializable.helpers import BaseHelper
+from py_serializable.helpers import BaseHelper
 
 from ..exception.serialization import CycloneDxDeserializationException, SerializationOfUnexpectedValueException
 from ..model.bom_ref import BomRef

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ keywords = [
 [tool.poetry.dependencies]
 python = "^3.8"
 packageurl-python = ">=0.11, <2"
-py-serializable =  "^1.1.1"
+py-serializable =  "^2.0.0"
 sortedcontainers = "^2.4.0"
 license-expression = "^30"
 jsonschema = { version = "^4.18", extras=['format'], optional=true }


### PR DESCRIPTION
bump to `py-serializable` v2.0.0: <https://github.com/madpah/serializable/releases/tag/v2.0.0>
This is considered a breaking change, as downstream users might rely on the same package's previous version.

