### PR TITLE
feat: avoid raising `NoPropertiesProvidedException` for optional parameters

### DIFF
--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -37,12 +37,7 @@ import serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple
-from ..exception.model import (
-    InvalidLocaleTypeException,
-    InvalidUriException,
-    NoPropertiesProvidedException,
-    UnknownHashTypeException,
-)
+from ..exception.model import InvalidLocaleTypeException, InvalidUriException, UnknownHashTypeException
 from ..exception.serialization import CycloneDxDeserializationException, SerializationOfUnexpectedValueException
 from ..schema.schema import (
     SchemaVersion1Dot0,
@@ -1180,11 +1175,6 @@ class IdentifiableAction:
         name: Optional[str] = None,
         email: Optional[str] = None,
     ) -> None:
-        if not timestamp and not name and not email:
-            raise NoPropertiesProvidedException(
-                'At least one of `timestamp`, `name` or `email` must be provided for an `IdentifiableAction`.'
-            )
-
         self.timestamp = timestamp
         self.name = name
         self.email = email

--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -29,7 +29,7 @@ from sortedcontainers import SortedSet
 from .._internal.bom_ref import bom_ref_from_str as _bom_ref_from_str
 from .._internal.compare import ComparablePackageURL as _ComparablePackageURL, ComparableTuple as _ComparableTuple
 from .._internal.hash import file_sha1sum as _file_sha1sum
-from ..exception.model import InvalidOmniBorIdException, InvalidSwhidException, NoPropertiesProvidedException
+from ..exception.model import InvalidOmniBorIdException, InvalidSwhidException
 from ..exception.serialization import (
     CycloneDxDeserializationException,
     SerializationOfUnexpectedValueException,
@@ -82,11 +82,6 @@ class Commit:
         committer: Optional[IdentifiableAction] = None,
         message: Optional[str] = None,
     ) -> None:
-        if not uid and not url and not author and not committer and not message:
-            raise NoPropertiesProvidedException(
-                'At least one of `uid`, `url`, `author`, `committer` or `message` must be provided for a `Commit`.'
-            )
-
         self.uid = uid
         self.url = url
         self.author = author
@@ -208,11 +203,6 @@ class ComponentEvidence:
         licenses: Optional[Iterable[License]] = None,
         copyright: Optional[Iterable[Copyright]] = None,
     ) -> None:
-        if not licenses and not copyright:
-            raise NoPropertiesProvidedException(
-                'At least one of `licenses` or `copyright` must be supplied for a `ComponentEvidence`.'
-            )
-
         self.licenses = licenses or []  # type:ignore[assignment]
         self.copyright = copyright or []  # type:ignore[assignment]
 
@@ -442,11 +432,6 @@ class Diff:
         text: Optional[AttachedText] = None,
         url: Optional[XsUri] = None,
     ) -> None:
-        if not text and not url:
-            raise NoPropertiesProvidedException(
-                'At least one of `text` or `url` must be provided for a `Diff`.'
-            )
-
         self.text = text
         self.url = url
 
@@ -624,12 +609,6 @@ class Pedigree:
         patches: Optional[Iterable[Patch]] = None,
         notes: Optional[str] = None,
     ) -> None:
-        if not ancestors and not descendants and not variants and not commits and not patches and not notes:
-            raise NoPropertiesProvidedException(
-                'At least one of `ancestors`, `descendants`, `variants`, `commits`, `patches` or `notes` must be '
-                'provided for `Pedigree`'
-            )
-
         self.ancestors = ancestors or []  # type:ignore[assignment]
         self.descendants = descendants or []  # type:ignore[assignment]
         self.variants = variants or []  # type:ignore[assignment]

--- a/cyclonedx/model/issue.py
+++ b/cyclonedx/model/issue.py
@@ -22,7 +22,6 @@ import serializable
 from sortedcontainers import SortedSet
 
 from .._internal.compare import ComparableTuple as _ComparableTuple
-from ..exception.model import NoPropertiesProvidedException
 from . import XsUri
 
 
@@ -54,10 +53,6 @@ class IssueTypeSource:
         name: Optional[str] = None,
         url: Optional[XsUri] = None,
     ) -> None:
-        if not name and not url:
-            raise NoPropertiesProvidedException(
-                'Neither `name` nor `url` were provided - at least one must be provided.'
-            )
         self.name = name
         self.url = url
 

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -229,11 +229,6 @@ class VulnerabilityAnalysis:
         responses: Optional[Iterable[ImpactAnalysisResponse]] = None,
         detail: Optional[str] = None,
     ) -> None:
-        if not state and not justification and not responses and not detail:
-            raise NoPropertiesProvidedException(
-                'At least one of state, justification, responses or detail must be provided for VulnerabilityAnalysis '
-                '- none supplied'
-            )
         self.state = state
         self.justification = justification
         self.responses = responses or []  # type:ignore[assignment]
@@ -416,10 +411,6 @@ class VulnerabilitySource:
         name: Optional[str] = None,
         url: Optional[XsUri] = None,
     ) -> None:
-        if not name and not url:
-            raise NoPropertiesProvidedException(
-                'Either name or url must be provided for a VulnerabilitySource - neither provided'
-            )
         self.name = name
         self.url = url
 
@@ -741,11 +732,6 @@ class VulnerabilityRating:
         vector: Optional[str] = None,
         justification: Optional[str] = None,
     ) -> None:
-        if not source and not score and not severity and not method and not vector and not justification:
-            raise NoPropertiesProvidedException(
-                'At least one property must be provided when creating a VulnerabilityRating - none supplied.'
-            )
-
         self.source = source
         self.score = score
         self.severity = severity
@@ -869,10 +855,6 @@ class VulnerabilityCredits:
         organizations: Optional[Iterable[OrganizationalEntity]] = None,
         individuals: Optional[Iterable[OrganizationalContact]] = None,
     ) -> None:
-        if not organizations and not individuals:
-            raise NoPropertiesProvidedException(
-                'One of `organizations` or `individuals` must be populated - neither were'
-            )
         self.organizations = organizations or []  # type:ignore[assignment]
         self.individuals = individuals or []  # type:ignore[assignment]
 

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -62,7 +62,7 @@ class BomTargetVersionRange:
     `version` and `version_range` are mutually exclusive.
 
     .. note::
-        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/#type_vulnerabilityType
+        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/xml/#type_vulnerabilityType
     """
 
     def __init__(
@@ -219,7 +219,7 @@ class VulnerabilityAnalysis:
     Class that models the `analysis` sub-element of the `vulnerabilityType` complex type.
 
     .. note::
-        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/#type_vulnerabilityType
+        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/xml/#type_vulnerabilityType
     """
 
     def __init__(
@@ -403,7 +403,7 @@ class VulnerabilitySource:
     This type is used for multiple purposes in the CycloneDX schema.
 
     .. note::
-        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/#type_vulnerabilitySourceType
+        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/xml/#type_vulnerabilitySourceType
     """
 
     def __init__(
@@ -471,7 +471,7 @@ class VulnerabilityReference:
     intelligence.
 
     .. note::
-        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/#type_vulnerabilityType
+        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/xml/#type_vulnerabilityType
     """
 
     def __init__(
@@ -714,7 +714,7 @@ class VulnerabilityRating:
     1.4 - see https://github.com/CycloneDX/specification/blob/master/schema/ext/vulnerability-1.0.xsd.
 
     .. note::
-        See `ratingType` in https://cyclonedx.org/docs/1.6/#ratingType
+        See `ratingType` in https://cyclonedx.org/docs/1.6/xml/#ratingType
 
     .. warning::
         As part of implementing support for CycloneDX schema version 1.4, the three score types defined in the schema
@@ -847,7 +847,7 @@ class VulnerabilityCredits:
     extension (in XML only).
 
     .. note::
-        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/#type_vulnerabilityType
+        See the CycloneDX schema: https://cyclonedx.org/docs/1.6/xml/#type_vulnerabilityType
     """
 
     def __init__(

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -24,12 +24,7 @@ from uuid import UUID
 from ddt import ddt, named_data
 
 from cyclonedx._internal.compare import ComparableTuple
-from cyclonedx.exception.model import (
-    InvalidLocaleTypeException,
-    InvalidUriException,
-    NoPropertiesProvidedException,
-    UnknownHashTypeException,
-)
+from cyclonedx.exception.model import InvalidLocaleTypeException, InvalidUriException, UnknownHashTypeException
 from cyclonedx.model import (
     Copyright,
     Encoding,
@@ -309,8 +304,7 @@ class TestModelHashType(TestCase):
 class TestModelIdentifiableAction(TestCase):
 
     def test_no_params(self) -> None:
-        with self.assertRaises(NoPropertiesProvidedException):
-            IdentifiableAction()
+        IdentifiableAction()  # Does not raise `NoPropertiesProvidedException`
 
     def test_same(self) -> None:
         ts = datetime.datetime.utcnow()

--- a/tests/test_model_component.py
+++ b/tests/test_model_component.py
@@ -19,7 +19,6 @@ import datetime
 from typing import List
 from unittest import TestCase
 
-from cyclonedx.exception.model import NoPropertiesProvidedException
 from cyclonedx.model import (
     AttachedText,
     Copyright,
@@ -57,8 +56,7 @@ from tests._data.models import (
 class TestModelCommit(TestCase):
 
     def test_no_parameters(self) -> None:
-        with self.assertRaises(NoPropertiesProvidedException):
-            Commit()
+        Commit()  # Does not raise `NoPropertiesProvidedException`
 
     def test_same(self) -> None:
         ia_comitter = IdentifiableAction(timestamp=datetime.datetime.utcnow(), name='The Committer')
@@ -287,8 +285,7 @@ class TestModelComponent(TestCase):
 class TestModelComponentEvidence(TestCase):
 
     def test_no_params(self) -> None:
-        with self.assertRaises(NoPropertiesProvidedException):
-            ComponentEvidence()
+        ComponentEvidence()  # Does not raise `NoPropertiesProvidedException`
 
     def test_same_1(self) -> None:
         ce_1 = ComponentEvidence(copyright=[Copyright(text='Commercial')])
@@ -312,8 +309,7 @@ class TestModelComponentEvidence(TestCase):
 class TestModelDiff(TestCase):
 
     def test_no_params(self) -> None:
-        with self.assertRaises(NoPropertiesProvidedException):
-            Diff()
+        Diff()  # Does not raise `NoPropertiesProvidedException`
 
     def test_same(self) -> None:
         at = AttachedText(content='A very long diff')
@@ -437,8 +433,7 @@ class TestModelPatch(TestCase):
 class TestModelPedigree(TestCase):
 
     def test_no_params(self) -> None:
-        with self.assertRaises(NoPropertiesProvidedException):
-            Pedigree()
+        Pedigree()  # does not raise `NoPropertiesProvidedException`
 
     def test_same_1(self) -> None:
         p1 = get_pedigree_1()

--- a/tests/test_model_issue.py
+++ b/tests/test_model_issue.py
@@ -17,7 +17,6 @@
 
 from unittest import TestCase
 
-from cyclonedx.exception.model import NoPropertiesProvidedException
 from cyclonedx.model import XsUri
 from cyclonedx.model.issue import IssueClassification, IssueType, IssueTypeSource
 from tests import reorder
@@ -63,8 +62,7 @@ class TestModelIssueType(TestCase):
 class TestModelIssueTypeSource(TestCase):
 
     def test_no_params(self) -> None:
-        with self.assertRaises(NoPropertiesProvidedException):
-            IssueTypeSource()
+        IssueTypeSource()  # Does not raise `NoPropertiesProvidedException`
 
     def test_same(self) -> None:
         its_1 = IssueTypeSource(name='The Source', url=XsUri('https://cyclonedx.org'))


### PR DESCRIPTION
the following classes' init no longer raise  `NoPropertiesProvidedException`:
* `cyclonedx.model.IdentifiableAction`
* `cyclonedx.model.component.Commit`
* `cyclonedx.model.component.ComponentEvidence`
* `cyclonedx.model.component.Diff`
* `cyclonedx.model.component.Pedigree`
* `cyclonedx.model.issue.IssueTypeSource`
* `cyclonedx.model.vulnerability.VulnerabilityAnalysis`
* `cyclonedx.model.vulnerability.VulnerabilityCredits`
* `cyclonedx.model.vulnerability.VulnerabilityRating`
* `cyclonedx.model.vulnerability.VulnerabilitySource`


----

did a global search and found these file/classes
raising this exception

File                -      Class
model/__init__.py   - IdentifiableAction
model/component.py  - Commit
model/component.py  - ComponentEvidence
model/component.py  - Diff
model/component.py  - Pedigree
model/issue.py      - IssueTypeSource
model/model.py      - BomTargetVersionRange
model/model.py      - VulnerabilityAnalysis
model/model.py      - VulnerabilitySource
model/model.py      - VulnerabilityReference
model/model.py      - VulnerabilityRating
model/model.py      - VulnerabilityCredits


fixes #776