### PR TITLE
fix: Add missing comparator for VulnerabilityAnalysis

### DIFF
--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -349,6 +349,11 @@ class VulnerabilityAnalysis:
             return self.__comparable_tuple() == other.__comparable_tuple()
         return False
 
+    def __lt__(self, other: Any) -> bool:
+        if isinstance(other, VulnerabilityAnalysis):
+            return self.__comparable_tuple() < other.__comparable_tuple()
+        return NotImplemented
+
     def __hash__(self) -> int:
         return hash(self.__comparable_tuple())
 

--- a/tests/test_model_vulnerability.py
+++ b/tests/test_model_vulnerability.py
@@ -20,12 +20,18 @@ from decimal import Decimal
 from unittest import TestCase
 
 from cyclonedx.model import XsUri
-from cyclonedx.model.impact_analysis import ImpactAnalysisAffectedStatus
+from cyclonedx.model.impact_analysis import (
+    ImpactAnalysisAffectedStatus,
+    ImpactAnalysisJustification,
+    ImpactAnalysisResponse,
+    ImpactAnalysisState,
+)
 from cyclonedx.model.vulnerability import (
     BomTarget,
     BomTargetVersionRange,
     Vulnerability,
     VulnerabilityAdvisory,
+    VulnerabilityAnalysis,
     VulnerabilityRating,
     VulnerabilityReference,
     VulnerabilityScoreSource,
@@ -334,3 +340,24 @@ class TestModelBomTarget(TestCase):
         sorted_targets = sorted(targets)
         expected_targets = reorder(targets, expected_order)
         self.assertListEqual(sorted_targets, expected_targets)
+
+
+class TestModelVulnerabilityAnalysis(TestCase):
+
+    def test_sort(self) -> None:
+        # expected sort order: ([state], [justification], [responses], [detail], [first_issued], [last_updated])
+        expected_order = [3, 1, 0, 2, 5, 4]
+        analyses = [
+            VulnerabilityAnalysis(state=ImpactAnalysisState.EXPLOITABLE),
+            VulnerabilityAnalysis(state=ImpactAnalysisState.EXPLOITABLE,
+                                  responses=[ImpactAnalysisResponse.CAN_NOT_FIX]),
+            VulnerabilityAnalysis(state=ImpactAnalysisState.NOT_AFFECTED,
+                                  justification=ImpactAnalysisJustification.CODE_NOT_PRESENT),
+            VulnerabilityAnalysis(state=ImpactAnalysisState.EXPLOITABLE,
+                                  justification=ImpactAnalysisJustification.REQUIRES_ENVIRONMENT),
+            VulnerabilityAnalysis(first_issued=datetime(2024, 4, 4), last_updated=datetime(2025, 5, 5)),
+            VulnerabilityAnalysis(first_issued=datetime(2023, 3, 3), last_updated=datetime(2023, 3, 3)),
+        ]
+        sorted_analyses = sorted(analyses)
+        expected_analyses = reorder(analyses, expected_order)
+        self.assertListEqual(sorted_analyses, expected_analyses)


### PR DESCRIPTION
When trying to generate a CycloneDX BOM that has two vulnerabilities that only differ in their analysis, you get
```
TypeError: '<' not supported between instances of 'VulnerabilityAnalysis' and 'VulnerabilityAnalysis'
```

This PR adds the `__lt__` method for the VulnerabilityAnalysis model to fix sorting and also includes a test case to verify the fix.