### PR TITLE
fix: add runtime dependnecy `typing_extensions>=4.6; python_version<"3.13"`

### DIFF
--- a/cyclonedx/serialization/__init__.py
+++ b/cyclonedx/serialization/__init__.py
@@ -28,7 +28,7 @@ from uuid import UUID
 from packageurl import PackageURL
 from py_serializable.helpers import BaseHelper
 
-if sys.version_info > (3, 13):
+if sys.version_info >= (3, 13):
     from warnings import deprecated
 else:
     from typing_extensions import deprecated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ sortedcontainers = "^2.4.0"
 license-expression = "^30"
 jsonschema = { version = "^4.18", extras=['format'], optional=true }
 lxml = { version=">=4,<7", optional=true }
+typing_extensions = { version="^4.6", python = "<3.13"}  # for `@deprecated` - which was added in v4.5 but this version appesrs to be broken...
 
 [tool.poetry.extras]
 validation = ["jsonschema", "lxml"]


### PR DESCRIPTION
fixes #844