### PR TITLE
feat!: ignore unknown properties when deserializing 

### DIFF
--- a/cyclonedx/model/__init__.py
+++ b/cyclonedx/model/__init__.py
@@ -676,7 +676,7 @@ class _ExternalReferenceSerializationHelper(serializable.helpers.BaseHelper):
         return ExternalReferenceType(o)
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class XsUri(serializable.helpers.BaseHelper):
     """
     Helper class that allows us to perform validation on data strings that are defined as xs:anyURI
@@ -802,7 +802,7 @@ class XsUri(serializable.helpers.BaseHelper):
         return self._uri.startswith(_BOM_LINK_PREFIX)
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class ExternalReference:
     """
     This is our internal representation of an ExternalReference complex type that can be used in multiple places within
@@ -914,7 +914,7 @@ class ExternalReference:
         return f'<ExternalReference {self.type.name}, {self.url}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Property:
     """
     This is our internal representation of `propertyType` complex type that can be used in multiple places within
@@ -989,7 +989,7 @@ class Property:
         return f'<Property name={self.name}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class NoteText:
     """
     This is our internal representation of the Note.text complex type that can be used in multiple places within
@@ -1081,7 +1081,7 @@ class NoteText:
         return f'<NoteText content_type={self.content_type}, encoding={self.encoding}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Note:
     """
     This is our internal representation of the Note complex type that can be used in multiple places within
@@ -1166,7 +1166,7 @@ class Note:
         return f'<Note id={id(self)}, locale={self.locale}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class IdentifiableAction:
     """
     This is our internal representation of the `identifiableActionType` complex type.
@@ -1252,7 +1252,7 @@ class IdentifiableAction:
         return f'<IdentifiableAction name={self.name}, email={self.email}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Copyright:
     """
     This is our internal representation of the `copyrightsType` complex type.

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from packageurl import PackageURL
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class BomMetaData:
     """
     This is our internal representation of the metadata complex type within the CycloneDX standard.
@@ -314,7 +314,7 @@ class BomMetaData:
         return f'<BomMetaData timestamp={self.timestamp}, component={self.component}>'
 
 
-@serializable.serializable_class(ignore_during_deserialization=['$schema', 'bom_format', 'spec_version'])
+@serializable.serializable_class(    ignore_unknown_during_deserialization=True)
 class Bom:
     """
     This is our internal representation of a bill-of-materials (BOM).

--- a/cyclonedx/model/bom.py
+++ b/cyclonedx/model/bom.py
@@ -314,7 +314,7 @@ class BomMetaData:
         return f'<BomMetaData timestamp={self.timestamp}, component={self.component}>'
 
 
-@serializable.serializable_class(    ignore_unknown_during_deserialization=True)
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Bom:
     """
     This is our internal representation of a bill-of-materials (BOM).

--- a/cyclonedx/model/bom_ref.py
+++ b/cyclonedx/model/bom_ref.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:  # pragma: no cover
     _T_BR = TypeVar('_T_BR', bound='BomRef')
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class BomRef(serializable.helpers.BaseHelper):
     """
     An identifier that can be used to reference objects elsewhere in the BOM.

--- a/cyclonedx/model/component.py
+++ b/cyclonedx/model/component.py
@@ -66,7 +66,7 @@ from .license import License, LicenseRepository, _LicenseRepositorySerialization
 from .release_note import ReleaseNotes
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Commit:
     """
     Our internal representation of the `commitType` complex type.
@@ -326,7 +326,7 @@ class _ComponentTypeSerializationHelper(serializable.helpers.BaseHelper):
         return ComponentType(o)
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Diff:
     """
     Our internal representation of the `diffType` complex type.
@@ -408,7 +408,7 @@ class PatchClassification(str, Enum):
     UNOFFICIAL = 'unofficial'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Patch:
     """
     Our internal representation of the `patchType` complex type.
@@ -498,7 +498,7 @@ class Patch:
         return f'<Patch type={self.type}, id={id(self)}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Pedigree:
     """
     Our internal representation of the `pedigreeType` complex type.
@@ -661,7 +661,7 @@ class Pedigree:
         return f'<Pedigree id={id(self)}, hash={hash(self)}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Swid:
     """
     Our internal representation of the `swidType` complex type.
@@ -813,7 +813,7 @@ class Swid:
         return f'<Swid tagId={self.tag_id}, name={self.name}, version={self.version}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class OmniborId(serializable.helpers.BaseHelper):
     """
     Helper class that allows us to perform validation on data strings that must conform to
@@ -872,7 +872,7 @@ class OmniborId(serializable.helpers.BaseHelper):
         return self._id
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Swhid(serializable.helpers.BaseHelper):
     """
     Helper class that allows us to perform validation on data strings that must conform to
@@ -931,7 +931,7 @@ class Swhid(serializable.helpers.BaseHelper):
         return self._id
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Component(Dependable):
     """
     This is our internal representation of a Component within a Bom.

--- a/cyclonedx/model/component_evidence.py
+++ b/cyclonedx/model/component_evidence.py
@@ -75,7 +75,7 @@ class AnalysisTechnique(str, Enum):
     OTHER = 'other'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Method:
     """
     Represents a method used to extract and/or analyze evidence.
@@ -181,7 +181,7 @@ class _IdentityToolRepositorySerializationHelper(serializable.helpers.BaseHelper
         return [BomRef(value=t.get('ref')) for t in o]
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Identity:
     """
     Our internal representation of the `identityType` complex type.
@@ -288,7 +288,7 @@ class Identity:
             f' methods={self.methods}, tools={self.tools}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Occurrence:
     """
     Our internal representation of the `occurrenceType` complex type.
@@ -423,7 +423,7 @@ class Occurrence:
         return f'<Occurrence location={self.location}, line={self.line}, symbol={self.symbol}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class CallStackFrame:
     """
     Represents an individual frame in a call stack.
@@ -567,7 +567,7 @@ class CallStackFrame:
                f' line={self.line}, column={self.column}, full_filename={self.full_filename}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class CallStack:
     """
     Our internal representation of the `callStackType` complex type.
@@ -622,7 +622,7 @@ class CallStack:
         return f'<CallStack frames={len(self.frames)}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class ComponentEvidence:
     """
     Our internal representation of the `componentEvidenceType` complex type.

--- a/cyclonedx/model/contact.py
+++ b/cyclonedx/model/contact.py
@@ -29,7 +29,7 @@ from . import XsUri
 from .bom_ref import BomRef
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class PostalAddress:
     """
     This is our internal representation of the `postalAddressType` complex type that can be used in multiple places
@@ -187,7 +187,7 @@ class PostalAddress:
         return f'<PostalAddress bom-ref={self.bom_ref}, street_address={self.street_address}, country={self.country}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class OrganizationalContact:
     """
     This is our internal representation of the `organizationalContact` complex type that can be used in multiple places
@@ -277,7 +277,7 @@ class OrganizationalContact:
         return f'<OrganizationalContact name={self.name}, email={self.email}, phone={self.phone}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class OrganizationalEntity:
     """
     This is our internal representation of the `organizationalEntity` complex type that can be used in multiple places

--- a/cyclonedx/model/crypto.py
+++ b/cyclonedx/model/crypto.py
@@ -263,7 +263,7 @@ class CryptoFunction(str, Enum):
     UNKNOWN = 'unknown'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class AlgorithmProperties:
     """
     This is our internal representation of the cryptoPropertiesType.algorithmProperties ENUM type within the CycloneDX
@@ -514,7 +514,7 @@ class AlgorithmProperties:
         return f'<AlgorithmProperties primitive={self.primitive}, execution_environment={self.execution_environment}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class CertificateProperties:
     """
     This is our internal representation of the `cryptoPropertiesType.certificateProperties` complex type within
@@ -746,7 +746,7 @@ class RelatedCryptoMaterialState(str, Enum):
     SUSPENDED = 'suspended'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class RelatedCryptoMaterialSecuredBy:
     """
     This is our internal representation of the `cryptoPropertiesType.relatedCryptoMaterialProperties.securedBy` complex
@@ -817,7 +817,7 @@ class RelatedCryptoMaterialSecuredBy:
         return f'<RelatedCryptoMaterialSecuredBy mechanism={self.mechanism}, algorithm_ref={self.algorithm_ref}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class RelatedCryptoMaterialProperties:
     """
     This is our internal representation of the `cryptoPropertiesType.relatedCryptoMaterialProperties` complex type
@@ -1086,7 +1086,7 @@ class ProtocolPropertiesType(str, Enum):
     UNKNOWN = 'unknown'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class ProtocolPropertiesCipherSuite:
     """
     This is our internal representation of the `cryptoPropertiesType.protocolProperties.cipherSuites.cipherSuite`
@@ -1179,7 +1179,7 @@ class ProtocolPropertiesCipherSuite:
         return f'<ProtocolPropertiesCipherSuite name={self.name}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Ikev2TransformTypes:
     """
     This is our internal representation of the `cryptoPropertiesType.protocolProperties.ikev2TransformTypes`
@@ -1321,7 +1321,7 @@ class Ikev2TransformTypes:
         return f'<Ikev2TransformTypes esn={self.esn}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class ProtocolProperties:
     """
     This is our internal representation of the `cryptoPropertiesType.protocolProperties` complex type within
@@ -1447,7 +1447,7 @@ class ProtocolProperties:
         return f'<ProtocolProperties type={self.type}, version={self.version}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class CryptoProperties:
     """
     This is our internal representation of the `cryptoPropertiesType` complex type within CycloneDX standard.

--- a/cyclonedx/model/definition.py
+++ b/cyclonedx/model/definition.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:  # pragma: no cover
     _T_CreId = TypeVar('_T_CreId', bound='CreId')
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class CreId(serializable.helpers.BaseHelper):
     """
     Helper class that allows us to perform validation on data strings that must conform to
@@ -89,7 +89,7 @@ class CreId(serializable.helpers.BaseHelper):
         return self._id
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Requirement:
     """
     A requirement comprising a standard.
@@ -282,7 +282,7 @@ class Requirement:
             f'title={self.title}, text={self.text}, parent={self.parent}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Level:
     """
     Level of compliance for a standard.
@@ -397,7 +397,7 @@ class Level:
             f'title={self.title}, description={self.description}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Standard:
     """
     A standard of regulations, industry or organizational-specific standards, maturity models, best practices,
@@ -574,7 +574,10 @@ class Standard:
             f'description={self.description}, owner={self.owner}>'
 
 
-@serializable.serializable_class(name='definitions')
+@serializable.serializable_class(
+    name='definitions',
+    ignore_unknown_during_deserialization=True
+)
 class Definitions:
     """
     The repository for definitions

--- a/cyclonedx/model/dependency.py
+++ b/cyclonedx/model/dependency.py
@@ -47,7 +47,7 @@ class _DependencyRepositorySerializationHelper(serializable.helpers.BaseHelper):
         return dependencies
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Dependency:
     """
     Models a Dependency within a BOM.

--- a/cyclonedx/model/issue.py
+++ b/cyclonedx/model/issue.py
@@ -39,7 +39,7 @@ class IssueClassification(str, Enum):
     SECURITY = 'security'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class IssueTypeSource:
     """
     This is our internal representation ofa source within the IssueType complex type that can be used in multiple
@@ -108,7 +108,7 @@ class IssueTypeSource:
         return f'<IssueTypeSource name={self._name}, url={self.url}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class IssueType:
     """
     This is our internal representation of an IssueType complex type that can be used in multiple places within

--- a/cyclonedx/model/license.py
+++ b/cyclonedx/model/license.py
@@ -60,7 +60,10 @@ LicenseExpressionAcknowledgement = LicenseAcknowledgement
 """Deprecated alias for :class:`LicenseAcknowledgement`"""
 
 
-@serializable.serializable_class(name='license')
+@serializable.serializable_class(
+    name='license',
+    ignore_unknown_during_deserialization=True
+)
 class DisjunctiveLicense:
     """
     This is our internal representation of `licenseType` complex type that can be used in multiple places within
@@ -245,7 +248,10 @@ class DisjunctiveLicense:
         return f'<License id={self._id!r}, name={self._name!r}>'
 
 
-@serializable.serializable_class(name='expression')
+@serializable.serializable_class(
+    name='expression',
+    ignore_unknown_during_deserialization=True
+)
 class LicenseExpression:
     """
     This is our internal representation of `licenseType`'s  expression type that can be used in multiple places within

--- a/cyclonedx/model/lifecycle.py
+++ b/cyclonedx/model/lifecycle.py
@@ -58,7 +58,7 @@ class LifecyclePhase(str, Enum):
     DECOMMISSION = 'decommission'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class PredefinedLifecycle:
     """
     Object that defines pre-defined phases in the product lifecycle.
@@ -97,7 +97,7 @@ class PredefinedLifecycle:
         return f'<PredefinedLifecycle phase={self._phase}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class NamedLifecycle:
     """
     Object that defines custom state in the product lifecycle.

--- a/cyclonedx/model/release_note.py
+++ b/cyclonedx/model/release_note.py
@@ -27,7 +27,7 @@ from ..model import Note, Property, XsUri
 from ..model.issue import IssueType
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class ReleaseNotes:
     """
     This is our internal representation of a `releaseNotesType` for a Component in a BOM.

--- a/cyclonedx/model/service.py
+++ b/cyclonedx/model/service.py
@@ -41,7 +41,7 @@ from .license import License, LicenseRepository, _LicenseRepositorySerialization
 from .release_note import ReleaseNotes
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Service(Dependable):
     """
     Class that models the `service` complex type in the CycloneDX schema.

--- a/cyclonedx/model/tool.py
+++ b/cyclonedx/model/tool.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from py_serializable import ObjectMetadataLibrary, ViewType
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Tool:
     """
     This is our internal representation of the `toolType` complex type within the CycloneDX standard.

--- a/cyclonedx/model/vulnerability.py
+++ b/cyclonedx/model/vulnerability.py
@@ -55,7 +55,7 @@ from .impact_analysis import (
 from .tool import Tool, ToolRepository, _ToolRepositoryHelper
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class BomTargetVersionRange:
     """
     Class that represents either a version or version range and its affected status.
@@ -148,7 +148,7 @@ class BomTargetVersionRange:
         return f'<BomTargetVersionRange version={self.version}, version_range={self.range}, status={self.status}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class BomTarget:
     """
     Class that represents referencing a Component or Service in a BOM.
@@ -221,7 +221,7 @@ class BomTarget:
         return f'<BomTarget ref={self.ref}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class VulnerabilityAnalysis:
     """
     Class that models the `analysis` sub-element of the `vulnerabilityType` complex type.
@@ -361,7 +361,7 @@ class VulnerabilityAnalysis:
         return f'<VulnerabilityAnalysis state={self.state}, justification={self.justification}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class VulnerabilityAdvisory:
     """
     Class that models the `advisoryType` complex type.
@@ -425,7 +425,7 @@ class VulnerabilityAdvisory:
         return f'<VulnerabilityAdvisory url={self.url}, title={self.title}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class VulnerabilitySource:
     """
     Class that models the `vulnerabilitySourceType` complex type.
@@ -491,7 +491,7 @@ class VulnerabilitySource:
         return f'<VulnerabilityAdvisory name={self.name}, url={self.url}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class VulnerabilityReference:
     """
     Class that models the nested `reference` within the `vulnerabilityType` complex type.
@@ -753,7 +753,7 @@ class VulnerabilitySeverity(str, Enum):
             return VulnerabilitySeverity.NONE
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class VulnerabilityRating:
     """
     Class that models the `ratingType` complex element CycloneDX core schema.
@@ -891,7 +891,7 @@ class VulnerabilityRating:
             f'justification={self.justification}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class VulnerabilityCredits:
     """
     Class that models the `credits` of `vulnerabilityType` complex type in the CycloneDX schema (version >= 1.4).
@@ -966,7 +966,7 @@ class VulnerabilityCredits:
         return f'<VulnerabilityCredits id={id(self)}>'
 
 
-@serializable.serializable_class
+@serializable.serializable_class(ignore_unknown_during_deserialization=True)
 class Vulnerability:
     """
     Class that models the `vulnerabilityType` complex type in the CycloneDX schema (version >= 1.4).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ keywords = [
 [tool.poetry.dependencies]
 python = "^3.9"
 packageurl-python = ">=0.11, <2"
-py-serializable =  "^2.0.0"
+py-serializable =  "^2.1.0"
 sortedcontainers = "^2.4.0"
 license-expression = "^30"
 jsonschema = { version = "^4.25", extras=['format-nongpl'], optional=true }

--- a/tests/_data/own/xml/1.6/regression_issue850.xml
+++ b/tests/_data/own/xml/1.6/regression_issue850.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" ?>
+<bom xmlns="http://cyclonedx.org/schema/bom/1.6"
+     xmlns:foo="http://example.com/foo"
+>
+    <components>
+        <component type="library"
+                   foo:my-prop="my-value"
+        >
+            <name>example</name>
+            <version>15.8.0</version>
+        </component>
+    </components>
+    <Signature xmlns="http://www.w3.org/2000/09/xmldsig#">
+        <!-- copy-pasted from https://github.com/CycloneDX/cyclonedx-python-lib/issues/850 -->
+        <SignedInfo>
+            <CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+            <SignatureMethod Algorithm="http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"/>
+            <Reference URI="">
+                <Transforms>
+                    <Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+                </Transforms>
+                <DigestMethod Algorithm="http://www.w3.org/2001/04/xmlenc#sha256"/>
+                <DigestValue>tSHVo7UgCxvvmFusf+2UzjhxXa2PyvLHaIvyNlB/yp8=</DigestValue>
+            </Reference>
+        </SignedInfo>
+        <SignatureValue>
+            gep3n58O7GLUk/jwmOda8HlwkiqA40CRhJYgoJbMJ6xZphfn7s/JHDByeptXvbolB6nVw5qAQ/mKCAkh0x7NGzWwSWypmpysK3zuUZuMihTSizd+kclwCJYamQ0l4Lqqp13Ii/6C8N56vlbci9P3NwOVC910Jj6GAFj2Ci4zCNz0tstpu7cDE2/okRR4jBzisOpr2FCaHWUfkZUiGm7ueCg/T+v2Z0HM8qcG//+iMlvHcb5yXKUObDvW8CYsMzNW0Zdhs/qf6WkPpp6QBeWxVB+5QUfMZ+F0fP3fRaerjwh6mGkOVl7QODHcIcp153yX8JxU+c0ndRacNywPBGmxTQ==
+        </SignatureValue>
+    </Signature>
+</bom>

--- a/tests/test_real_world_examples.py
+++ b/tests/test_real_world_examples.py
@@ -38,6 +38,10 @@ class TestDeserializeRealWorldExamples(unittest.TestCase):
         with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue630.xml')) as input_xml:
             Bom.from_xml(input_xml)
 
+    def test_regression_issue_850(self, *_: Any, **__: Any) -> None:
+        with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue850.xml')) as input_xml:
+            Bom.from_xml(input_xml)
+
     def test_regression_issue677(self, *_: Any, **__: Any) -> None:
         # tests https://github.com/CycloneDX/cyclonedx-python-lib/issues/677
         with open(join(OWN_DATA_DIRECTORY, 'json', '1.5', 'issue677.json')) as input_json:

--- a/tests/test_real_world_examples.py
+++ b/tests/test_real_world_examples.py
@@ -39,6 +39,7 @@ class TestDeserializeRealWorldExamples(unittest.TestCase):
             Bom.from_xml(input_xml)
 
     def test_regression_issue_850(self, *_: Any, **__: Any) -> None:
+        # tests https://github.com/CycloneDX/cyclonedx-python-lib/issues/850
         with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue850.xml')) as input_xml:
             Bom.from_xml(input_xml)
 

--- a/tests/test_real_world_examples.py
+++ b/tests/test_real_world_examples.py
@@ -38,11 +38,6 @@ class TestDeserializeRealWorldExamples(unittest.TestCase):
         with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue630.xml')) as input_xml:
             Bom.from_xml(input_xml)
 
-    def test_regression_issue_850(self, *_: Any, **__: Any) -> None:
-        # tests https://github.com/CycloneDX/cyclonedx-python-lib/issues/850
-        with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue850.xml')) as input_xml:
-            Bom.from_xml(input_xml)
-
     def test_regression_issue677(self, *_: Any, **__: Any) -> None:
         # tests https://github.com/CycloneDX/cyclonedx-python-lib/issues/677
         with open(join(OWN_DATA_DIRECTORY, 'json', '1.5', 'issue677.json')) as input_json:
@@ -58,3 +53,8 @@ class TestDeserializeRealWorldExamples(unittest.TestCase):
         bom = Bom.from_json(json)
         self.assertEqual(2, len(bom.components))
         bom.validate()
+
+    def test_regression_issue_850(self, *_: Any, **__: Any) -> None:
+        # tests https://github.com/CycloneDX/cyclonedx-python-lib/issues/850
+        with open(join(OWN_DATA_DIRECTORY, 'xml', '1.6', 'regression_issue850.xml')) as input_xml:
+            Bom.from_xml(input_xml)


### PR DESCRIPTION
when deserializing JSON: ignore unknown/unsupported properties
when deserializing XML: ignore unknown/unsupported attributes and elements

this is considered a **BREAKING Change**, as the old behavior was to throw an error when deserializing unknown/unsupported features - which no longer happens, instead, unknown/unsupported features are simply ignored.

-----

- fixes #850 

-----

