### PR TITLE
feat: use only nonGPL dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ packageurl-python = ">=0.11, <2"
 py-serializable =  "^2.0.0"
 sortedcontainers = "^2.4.0"
 license-expression = "^30"
-jsonschema = { version = "^4.18", extras=['format'], optional=true }
+jsonschema = { version = "^4.25", extras=['format-nongpl'], optional=true }
 referencing = { version = ">=0.28.4", optional=true }  # in sync with the transitive dependency of `jsonschema`
 lxml = { version=">=4,<7", optional=true }
 typing_extensions = { version="^4.6", python = "<3.13"}  # for `@deprecated` - which was added in v4.5 but this version appesrs to be broken...


### PR DESCRIPTION
change optional dependency from `jsonschemap[format]>=4.18,<5` to `jsonschemap[format-nongpl]>=4.25,<5`

- requires https://github.com/python-jsonschema/jsonschema/releases/tag/v4.25.0
- fixes #743

considered a non-breaking change, since all functionality and capabilities stay the same. 