### PR TITLE
[IDEA] feat!: discriminate every BomRef as promissed

### DIFF
--- a/tests/_data/models.py
+++ b/tests/_data/models.py
@@ -21,7 +21,7 @@ from collections.abc import Iterable
 from datetime import datetime, timezone
 from decimal import Decimal
 from inspect import getmembers, isfunction
-from typing import Any, Optional
+from typing import Any
 from uuid import UUID
 
 # See https://github.com/package-url/packageurl-python/issues/65
@@ -284,8 +284,9 @@ def get_crypto_properties_related_material() -> CryptoProperties:
 
 def get_bom_with_component_setuptools_with_v16_fields() -> Bom:
     component = get_component_setuptools_simple()
-    component.manufacturer = get_org_entity_1()
-    component.authors = [get_org_contact_1(), get_org_contact_2()]
+    component.manufacturer = get_org_entity_1(f'_{component.bom_ref.value}_manufacturer')
+    component.authors = [get_org_contact_1(f'_{component.bom_ref.value}_authors1'),
+                         get_org_contact_2(f'_{component.bom_ref.value}_authors2')]
     component.omnibor_ids = [OmniborId('gitoid:blob:sha1:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64')]
     component.swhids = [
         Swhid('swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2'),
@@ -306,16 +307,18 @@ def get_bom_with_component_setuptools_with_v16_fields() -> Bom:
 
 def get_bom_with_component_setuptools_with_v16_fields_omnibor_id_invalid() -> Bom:
     component = get_component_setuptools_simple()
-    component.manufacturer = get_org_entity_1()
-    component.authors = [get_org_contact_1(), get_org_contact_2()]
+    component.manufacturer = get_org_entity_1(f'_{component.bom_ref.value}_manufacturer')
+    component.authors = [get_org_contact_1(f'_{component.bom_ref.value}_authors1'),
+                         get_org_contact_2(f'_{component.bom_ref.value}_authors2')]
     component.omnibor_ids = [OmniborId('gitoid:stuff:sha1:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64')]
     return _make_bom(components=[component])
 
 
 def get_bom_with_component_setuptools_with_v16_fields_swhid_invalid() -> Bom:
     component = get_component_setuptools_simple()
-    component.manufacturer = get_org_entity_1()
-    component.authors = [get_org_contact_1(), get_org_contact_2()]
+    component.manufacturer = get_org_entity_1(f'_{component.bom_ref.value}_manufacturer')
+    component.authors = [get_org_contact_1(f'_{component.bom_ref.value}_authors1'),
+                         get_org_contact_2(f'_{component.bom_ref.value}_authors2')]
     component.omnibor_ids = [OmniborId('gitoid:blob:sha1:261eeb9e9f8b2b4b0d119366dda99c6fd7d35c64')]
     component.swhids = [
         Swhid('swh:1:cntp:94a9ed024d3859793618152ea559a168bbcbb5e2'),
@@ -324,7 +327,7 @@ def get_bom_with_component_setuptools_with_v16_fields_swhid_invalid() -> Bom:
 
 
 def get_component_crypto_asset_algorithm(
-    bom_ref: Optional[str] = '8182921e-0588-472e-b8f9-9c527c68f067'
+    bom_ref: str = '8182921e-0588-472e-b8f9-9c527c68f067'
 ) -> Component:
     return Component(
         name='My Algorithm', version='1.0', type=ComponentType.CRYPTOGRAPHIC_ASSET,
@@ -335,7 +338,7 @@ def get_component_crypto_asset_algorithm(
 
 
 def get_component_crypto_asset_certificate(
-    bom_ref: Optional[str] = '1f4ed1e4-582a-4fa0-8c38-1b4facc16972'
+    bom_ref: str = '1f4ed1e4-582a-4fa0-8c38-1b4facc16972'
 ) -> Component:
     return Component(
         name='My Certificate', version='1.0', type=ComponentType.CRYPTOGRAPHIC_ASSET,
@@ -346,7 +349,7 @@ def get_component_crypto_asset_certificate(
 
 
 def get_component_crypto_asset_protocol_tls_v13(
-    bom_ref: Optional[str] = '26b1ce0f-bec6-4bfe-9db1-03b75a4ed1ec'
+    bom_ref: str = '26b1ce0f-bec6-4bfe-9db1-03b75a4ed1ec'
 ) -> Component:
     return Component(
         name='TLS', version='v1.3', type=ComponentType.CRYPTOGRAPHIC_ASSET,
@@ -357,7 +360,7 @@ def get_component_crypto_asset_protocol_tls_v13(
 
 
 def get_component_crypto_asset_related_material(
-    bom_ref: Optional[str] = '332b3cee-078c-4789-ab15-887565b6fac5'
+    bom_ref: str = '332b3cee-078c-4789-ab15-887565b6fac5'
 ) -> Component:
     return Component(
         name='My Encrypted Thing', version='1.0', type=ComponentType.CRYPTOGRAPHIC_ASSET,
@@ -476,7 +479,7 @@ def get_bom_with_component_evidence() -> Bom:
     bom.metadata.component = Component(
         name='root-component',
         type=ComponentType.APPLICATION,
-        licenses=[DisjunctiveLicense(id='MIT')],
+        licenses=[DisjunctiveLicense(bom_ref='root_c_license', id='MIT')],
         bom_ref='myApp',
     )
     component = Component(
@@ -485,7 +488,7 @@ def get_bom_with_component_evidence() -> Bom:
         purl=PackageURL(
             type='pypi', name='setuptools', version='50.3.2', qualifiers='extension=tar.gz'
         ),
-        licenses=[DisjunctiveLicense(id='MIT')],
+        licenses=[DisjunctiveLicense(bom_ref='c_license', id='MIT')],
         author='Test Author'
     )
     component.evidence = get_component_evidence_basic(tools=[tool_component])
@@ -533,9 +536,9 @@ def get_bom_with_component_setuptools_with_vulnerability() -> Bom:
                          tzinfo=timezone.utc),
         credits=VulnerabilityCredits(
             organizations=[
-                get_org_entity_1()
+                get_org_entity_1('_vuln_credits_org')
             ],
-            individuals=[get_org_contact_2()]
+            individuals=[get_org_contact_2('_vuln_credits_ind')]
         ),
         tools=ToolRepository(tools=(
             Tool(vendor='CycloneDX', name='cyclonedx-python-lib'),
@@ -567,12 +570,13 @@ def get_bom_with_component_toml_1() -> Bom:
 
 def get_bom_just_complete_metadata() -> Bom:
     bom = _make_bom()
-    bom.metadata.authors = [get_org_contact_1(), get_org_contact_2()]
+    bom.metadata.authors = [get_org_contact_1('_bom_authors'), get_org_contact_2('_bom_authors')]
     bom.metadata.component = get_component_setuptools_complete()
-    bom.metadata.component.manufacturer = get_org_entity_1()
-    bom.metadata.manufacture = get_org_entity_1()  # Deprecated from v1.6 onwards
-    bom.metadata.supplier = get_org_entity_2()
+    bom.metadata.component.manufacturer = get_org_entity_1('_rc_manufacturer')
+    bom.metadata.manufacture = get_org_entity_1('_bom_manufacture')  # Deprecated from v1.6 onwards
+    bom.metadata.supplier = get_org_entity_2('_bom_supplier')
     bom.metadata.licenses = [DisjunctiveLicense(
+        bom_ref='bom_license',
         id='Apache-2.0',
         url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.txt'),
         text=AttachedText(
@@ -608,7 +612,7 @@ def get_bom_with_services_complex() -> Bom:
     bom = _make_bom(services=[
         Service(
             name='my-first-service', bom_ref='my-specific-bom-ref-for-my-first-service',
-            provider=get_org_entity_1(), group='a-group', version='1.2.3',
+            provider=get_org_entity_1('_s1'), group='a-group', version='1.2.3',
             description='Description goes here', endpoints=[
                 XsUri('/api/thing/1'),
                 XsUri('/api/thing/2')
@@ -616,7 +620,7 @@ def get_bom_with_services_complex() -> Bom:
             authenticated=False, x_trust_boundary=True, data=[
                 DataClassification(flow=DataFlow.OUTBOUND, classification='public')
             ],
-            licenses=[DisjunctiveLicense(name='Commercial')],
+            licenses=[DisjunctiveLicense(bom_ref='service_license', name='Commercial')],
             external_references=[
                 get_external_reference_1()
             ],
@@ -636,7 +640,7 @@ def get_bom_with_nested_services() -> Bom:
     bom = _make_bom(services=[
         Service(
             name='my-first-service', bom_ref='my-specific-bom-ref-for-my-first-service',
-            provider=get_org_entity_1(), group='a-group', version='1.2.3',
+            provider=get_org_entity_1('_s1'), group='a-group', version='1.2.3',
             description='Description goes here', endpoints=[
                 XsUri('/api/thing/1'),
                 XsUri('/api/thing/2')
@@ -644,7 +648,7 @@ def get_bom_with_nested_services() -> Bom:
             authenticated=False, x_trust_boundary=True, data=[
                 DataClassification(flow=DataFlow.OUTBOUND, classification='public')
             ],
-            licenses=[DisjunctiveLicense(name='Commercial')],
+            licenses=[DisjunctiveLicense(bom_ref='service_license', name='Commercial')],
             external_references=[
                 get_external_reference_1()
             ],
@@ -655,7 +659,7 @@ def get_bom_with_nested_services() -> Bom:
                 ),
                 Service(
                     name='second-nested-service', bom_ref='my-specific-bom-ref-for-second-nested-service',
-                    provider=get_org_entity_1(), group='no-group', version='3.2.1',
+                    provider=get_org_entity_1('_s2'), group='no-group', version='3.2.1',
                     authenticated=True, x_trust_boundary=False,
                 )
             ],
@@ -668,7 +672,7 @@ def get_bom_with_nested_services() -> Bom:
                 Service(
                     name='yet-another-nested-service',
                     bom_ref='yet-another-nested-service',
-                    provider=get_org_entity_1(), group='what-group', version='6.5.4'
+                    provider=get_org_entity_1('_s3'), group='what-group', version='6.5.4'
                 ),
                 Service(
                     name='another-nested-service',
@@ -754,7 +758,7 @@ def get_bom_for_issue_328_components() -> Bom:
 
 def get_component_setuptools_complete(include_pedigree: bool = True) -> Component:
     component = get_component_setuptools_simple(bom_ref='my-specific-bom-ref-for-dings')
-    component.supplier = get_org_entity_1()
+    component.supplier = get_org_entity_1(f'_{component.bom_ref.value}')
     component.publisher = 'CycloneDX'
     component.description = 'This component is awesome'
     component.scope = ComponentScope.REQUIRED
@@ -831,7 +835,7 @@ def get_component_evidence_basic(tools: Iterable[Component]) -> ComponentEvidenc
                 )
             ]
         ),
-        licenses=[DisjunctiveLicense(id='MIT')],
+        licenses=[DisjunctiveLicense(bom_ref='evidence_license', id='MIT')],
         copyright=[
             Copyright(text='Commercial'), Copyright(text='Commercial 2')
         ]
@@ -839,7 +843,7 @@ def get_component_evidence_basic(tools: Iterable[Component]) -> ComponentEvidenc
 
 
 def get_component_setuptools_simple(
-    bom_ref: Optional[str] = 'pkg:pypi/setuptools@50.3.2?extension=tar.gz'
+    bom_ref: str = 'pkg:pypi/setuptools@50.3.2?extension=tar.gz'
 ) -> Component:
     return Component(
         name='setuptools', version='50.3.2',
@@ -847,25 +851,25 @@ def get_component_setuptools_simple(
         purl=PackageURL(
             type='pypi', name='setuptools', version='50.3.2', qualifiers='extension=tar.gz'
         ),
-        licenses=[DisjunctiveLicense(id='MIT')],
+        licenses=[DisjunctiveLicense(bom_ref=f'{bom_ref}_license', id='MIT')],
         author='Test Author'
     )
 
 
-def get_component_setuptools_simple_no_version(bom_ref: Optional[str] = None) -> Component:
+def get_component_setuptools_simple_no_version(bom_ref: str = 'pkg:pypi/setuptools?extension=tar.gz') -> Component:
     return Component(
-        name='setuptools', bom_ref=bom_ref or 'pkg:pypi/setuptools?extension=tar.gz',
+        name='setuptools', bom_ref=bom_ref,
         purl=PackageURL(
             type='pypi', name='setuptools', qualifiers='extension=tar.gz'
         ),
-        licenses=[DisjunctiveLicense(id='MIT')],
+        licenses=[DisjunctiveLicense(bom_ref=f'{bom_ref}_license', id='MIT')],
         author='Test Author'
     )
 
 
-def get_component_toml_with_hashes_with_references(bom_ref: Optional[str] = None) -> Component:
+def get_component_toml_with_hashes_with_references(bom_ref: str = 'pkg:pypi/toml@0.10.2?extension=tar.gz') -> Component:
     return Component(
-        name='toml', version='0.10.2', bom_ref=bom_ref or 'pkg:pypi/toml@0.10.2?extension=tar.gz',
+        name='toml', version='0.10.2', bom_ref=bom_ref,
         purl=PackageURL(
             type='pypi', name='toml', version='0.10.2', qualifiers='extension=tar.gz'
         ), hashes=[
@@ -919,34 +923,43 @@ def get_issue_2() -> IssueType:
     )
 
 
-def get_org_contact_1() -> OrganizationalContact:
-    return OrganizationalContact(name='Paul Horton', email='paul.horton@owasp.org')
+def get_org_contact_1(br_postfix: str = '') -> OrganizationalContact:
+    return OrganizationalContact(
+        bom_ref=f'OrganizationalContact_ph{br_postfix}',
+        name='Paul Horton', email='paul.horton@owasp.org')
 
 
-def get_org_contact_2() -> OrganizationalContact:
-    return OrganizationalContact(name='A N Other', email='someone@somewhere.tld', phone='+44 (0)1234 567890')
+def get_org_contact_2(br_postfix: str = '') -> OrganizationalContact:
+    return OrganizationalContact(
+        bom_ref=f'OrganizationalContact_ano{br_postfix}',
+        name='A N Other', email='someone@somewhere.tld', phone='+44 (0)1234 567890')
 
 
-def get_postal_address_1() -> PostalAddress:
-    return PostalAddress(country='GB', region='England', locality='Cheshire', street_address='100 Main Street')
+def get_postal_address_1(br_postfix: str = '') -> PostalAddress:
+    return PostalAddress(bom_ref=f'PostalAddress_1{br_postfix}',
+                         country='GB', region='England', locality='Cheshire', street_address='100 Main Street')
 
 
-def get_postal_address_2() -> PostalAddress:
-    return PostalAddress(country='US', region='Texas', locality='Austin', street_address='100 Yee-Ha Street',
+def get_postal_address_2(br_postfix: str = '') -> PostalAddress:
+    return PostalAddress(bom_ref=f'PostalAddress_2{br_postfix}',
+                         country='US', region='Texas', locality='Austin', street_address='100 Yee-Ha Street',
                          postal_code='12345', post_office_box_number='105a')
 
 
-def get_org_entity_1() -> OrganizationalEntity:
+def get_org_entity_1(br_postfix: str = '') -> OrganizationalEntity:
     return OrganizationalEntity(
+        bom_ref=f'OrganizationalEntity_cdx{br_postfix}',
         name='CycloneDX', urls=[XsUri('https://cyclonedx.org'), XsUri('https://cyclonedx.org/docs')],
-        contacts=[get_org_contact_1(), get_org_contact_2()], address=get_postal_address_1()
+        contacts=[get_org_contact_1(br_postfix), get_org_contact_2(br_postfix)],
+        address=get_postal_address_1(br_postfix)
     )
 
 
-def get_org_entity_2() -> OrganizationalEntity:
+def get_org_entity_2(br_postfix: str = '') -> OrganizationalEntity:
     return OrganizationalEntity(
-        name='Cyclone DX', urls=[XsUri('https://cyclonedx.org/')], contacts=[get_org_contact_2()],
-        address=get_postal_address_2()
+        bom_ref=f'OrganizationalEntity_cd_x{br_postfix}',
+        name='Cyclone DX', urls=[XsUri('https://cyclonedx.org/')], contacts=[get_org_contact_2(br_postfix)],
+        address=get_postal_address_2(br_postfix)
     )
 
 
@@ -1051,39 +1064,47 @@ def get_vulnerability_source_owasp() -> VulnerabilitySource:
 def get_bom_with_licenses() -> Bom:
     return _make_bom(
         metadata=BomMetaData(
-            licenses=[DisjunctiveLicense(id='CC-BY-1.0')],
+            licenses=[DisjunctiveLicense(bom_ref='bom_license', id='CC-BY-1.0')],
             component=Component(name='app', type=ComponentType.APPLICATION, bom_ref='my-app',
-                                licenses=[DisjunctiveLicense(name='proprietary')])
+                                licenses=[DisjunctiveLicense(bom_ref='root_component_license', name='proprietary')])
         ),
         components=[
             Component(name='c-with-expression', type=ComponentType.LIBRARY, bom_ref='C1',
-                      licenses=[LicenseExpression(value='Apache-2.0 OR MIT',
+                      licenses=[LicenseExpression(bom_ref='C1_license',
+                                                  value='Apache-2.0 OR MIT',
                                                   acknowledgement=LicenseAcknowledgement.CONCLUDED)]),
             Component(name='c-with-SPDX', type=ComponentType.LIBRARY, bom_ref='C2',
-                      licenses=[DisjunctiveLicense(id='Apache-2.0',
+                      licenses=[DisjunctiveLicense(bom_ref='C2_license',
+                                                   id='Apache-2.0',
                                                    url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.html'),
                                                    acknowledgement=LicenseAcknowledgement.CONCLUDED)]),
             Component(name='c-with-name', type=ComponentType.LIBRARY, bom_ref='C3',
                       licenses=[
-                          DisjunctiveLicense(name='some commercial license',
+                          DisjunctiveLicense(bom_ref='c-with-name_license_1',
+                                             name='some commercial license',
                                              text=AttachedText(content='this is a license text')),
-                          DisjunctiveLicense(name='some additional',
+                          DisjunctiveLicense(bom_ref='c-with-name_license_2',
+                                             name='some additional',
                                              text=AttachedText(content='this is additional license text')),
                       ]),
         ],
         services=[
             Service(name='s-with-expression', bom_ref='S1',
-                    licenses=[LicenseExpression(value='Apache-2.0 OR MIT',
+                    licenses=[LicenseExpression(bom_ref='S1_license',
+                                                value='Apache-2.0 OR MIT',
                                                 acknowledgement=LicenseAcknowledgement.DECLARED)]),
             Service(name='s-with-SPDX', bom_ref='S2',
-                    licenses=[DisjunctiveLicense(id='Apache-2.0',
+                    licenses=[DisjunctiveLicense(bom_ref='S2_license',
+                                                 id='Apache-2.0',
                                                  url=XsUri('https://www.apache.org/licenses/LICENSE-2.0.html'),
                                                  acknowledgement=LicenseAcknowledgement.DECLARED)]),
             Service(name='s-with-name', bom_ref='S3',
                     licenses=[
-                        DisjunctiveLicense(name='some commercial license',
+                        DisjunctiveLicense(bom_ref='S3_license1',
+                                           name='some commercial license',
                                            text=AttachedText(content='this is a license text')),
-                        DisjunctiveLicense(name='some additional',
+                        DisjunctiveLicense(bom_ref='S3_license2',
+                                           name='some additional',
                                            text=AttachedText(content='this is additional license text')),
                     ]),
         ])
@@ -1140,20 +1161,21 @@ def get_bom_service_licenses_invalid() -> Bom:
 
 
 def get_bom_with_multiple_licenses() -> Bom:
-    multi_licenses = (
-        DisjunctiveLicense(id='MIT'),
-        DisjunctiveLicense(name='foo license'),
-    )
+    def multi_licenses(br_prefix: str) -> tuple[DisjunctiveLicense, ...]:
+        return (
+            DisjunctiveLicense(bom_ref=f'{br_prefix}_license_mit', id='MIT'),
+            DisjunctiveLicense(bom_ref=f'{br_prefix}_license_foo', name='foo license'),
+        )
     return _make_bom(
         metadata=BomMetaData(
-            licenses=multi_licenses,
+            licenses=multi_licenses('bom'),
             component=Component(name='app', type=ComponentType.APPLICATION, bom_ref='my-app',
-                                licenses=multi_licenses)
+                                licenses=multi_licenses('my-app'))
         ),
         components=[Component(name='comp', type=ComponentType.LIBRARY, bom_ref='my-compo',
-                              licenses=multi_licenses)],
+                              licenses=multi_licenses('my-compo'))],
         services=[Service(name='serv', bom_ref='my-serv',
-                          licenses=multi_licenses)]
+                          licenses=multi_licenses('my-serv'))]
     )
 
 

--- a/tests/_data/snapshots/enum_Encoding-1.5.json.bin
+++ b/tests/_data/snapshots/enum_Encoding-1.5.json.bin
@@ -5,6 +5,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "dummy_license",
             "name": "att.encoding: BASE_64",
             "text": {
               "content": "att.encoding: BASE_64",

--- a/tests/_data/snapshots/enum_Encoding-1.5.xml.bin
+++ b/tests/_data/snapshots/enum_Encoding-1.5.xml.bin
@@ -7,7 +7,7 @@
     <component type="library" bom-ref="dummy">
       <name>dummy</name>
       <licenses>
-        <license>
+        <license bom-ref="dummy_license">
           <name>att.encoding: BASE_64</name>
           <text content-type="text/plain" encoding="base64">att.encoding: BASE_64</text>
         </license>

--- a/tests/_data/snapshots/enum_Encoding-1.6.json.bin
+++ b/tests/_data/snapshots/enum_Encoding-1.6.json.bin
@@ -5,6 +5,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "dummy_license",
             "name": "att.encoding: BASE_64",
             "text": {
               "content": "att.encoding: BASE_64",

--- a/tests/_data/snapshots/enum_Encoding-1.6.xml.bin
+++ b/tests/_data/snapshots/enum_Encoding-1.6.xml.bin
@@ -7,7 +7,7 @@
     <component type="library" bom-ref="dummy">
       <name>dummy</name>
       <licenses>
-        <license>
+        <license bom-ref="dummy_license">
           <name>att.encoding: BASE_64</name>
           <text content-type="text/plain" encoding="base64">att.encoding: BASE_64</text>
         </license>

--- a/tests/_data/snapshots/get_bom_just_complete_metadata-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_just_complete_metadata-1.5.json.bin
@@ -7,11 +7,13 @@
   "metadata": {
     "authors": [
       {
+        "bom-ref": "OrganizationalContact_ano_bom_authors",
         "email": "someone@somewhere.tld",
         "name": "A N Other",
         "phone": "+44 (0)1234 567890"
       },
       {
+        "bom-ref": "OrganizationalContact_ph_bom_authors",
         "email": "paul.horton@owasp.org",
         "name": "Paul Horton"
       }
@@ -26,6 +28,7 @@
           "licenses": [
             {
               "license": {
+                "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
                 "id": "MIT"
               }
             }
@@ -91,6 +94,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-specific-bom-ref-for-dings_license",
             "id": "MIT"
           }
         }
@@ -104,6 +108,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ccc8d7ee-4b9c-4750-aee0-a72585152291_license",
                   "id": "MIT"
                 }
               }
@@ -119,6 +124,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "8a3893b3-9923-4adb-a1d3-47456636ba0a_license",
                   "id": "MIT"
                 }
               }
@@ -141,6 +147,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "28b2d8ce-def0-446f-a221-58dee0b44acc_license",
                   "id": "MIT"
                 }
               }
@@ -197,6 +204,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ded1d73e-1fca-4302-b520-f1bc53979958_license",
                   "id": "MIT"
                 }
               }
@@ -307,13 +315,16 @@
       },
       "scope": "required",
       "supplier": {
+        "bom-ref": "OrganizationalEntity_cdx_my-specific-bom-ref-for-dings",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_my-specific-bom-ref-for-dings",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_my-specific-bom-ref-for-dings",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }
@@ -340,6 +351,7 @@
     "licenses": [
       {
         "license": {
+          "bom-ref": "bom_license",
           "id": "Apache-2.0",
           "text": {
             "content": "VGVzdCBjb250ZW50IC0gdGhpcyBpcyBub3QgdGhlIEFwYWNoZSAyLjAgbGljZW5zZSE=",
@@ -356,13 +368,16 @@
       }
     ],
     "manufacture": {
+      "bom-ref": "OrganizationalEntity_cdx_bom_manufacture",
       "contact": [
         {
+          "bom-ref": "OrganizationalContact_ano_bom_manufacture",
           "email": "someone@somewhere.tld",
           "name": "A N Other",
           "phone": "+44 (0)1234 567890"
         },
         {
+          "bom-ref": "OrganizationalContact_ph_bom_manufacture",
           "email": "paul.horton@owasp.org",
           "name": "Paul Horton"
         }
@@ -384,8 +399,10 @@
       }
     ],
     "supplier": {
+      "bom-ref": "OrganizationalEntity_cd_x_bom_supplier",
       "contact": [
         {
+          "bom-ref": "OrganizationalContact_ano_bom_supplier",
           "email": "someone@somewhere.tld",
           "name": "A N Other",
           "phone": "+44 (0)1234 567890"

--- a/tests/_data/snapshots/get_bom_just_complete_metadata-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_just_complete_metadata-1.5.xml.bin
@@ -8,27 +8,27 @@
       </lifecycle>
     </lifecycles>
     <authors>
-      <author>
+      <author bom-ref="OrganizationalContact_ano_bom_authors">
         <name>A N Other</name>
         <email>someone@somewhere.tld</email>
         <phone>+44 (0)1234 567890</phone>
       </author>
-      <author>
+      <author bom-ref="OrganizationalContact_ph_bom_authors">
         <name>Paul Horton</name>
         <email>paul.horton@owasp.org</email>
       </author>
     </authors>
     <component type="library" bom-ref="my-specific-bom-ref-for-dings">
-      <supplier>
+      <supplier bom-ref="OrganizationalEntity_cdx_my-specific-bom-ref-for-dings">
         <name>CycloneDX</name>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_my-specific-bom-ref-for-dings">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_my-specific-bom-ref-for-dings">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -40,7 +40,7 @@
       <description>This component is awesome</description>
       <scope>required</scope>
       <licenses>
-        <license>
+        <license bom-ref="my-specific-bom-ref-for-dings_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -57,7 +57,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ccc8d7ee-4b9c-4750-aee0-a72585152291_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -67,7 +67,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="8a3893b3-9923-4adb-a1d3-47456636ba0a_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -79,7 +79,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="28b2d8ce-def0-446f-a221-58dee0b44acc_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -109,7 +109,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ded1d73e-1fca-4302-b520-f1bc53979958_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -168,7 +168,7 @@
           <name>setuptools</name>
           <version>50.3.2</version>
           <licenses>
-            <license>
+            <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
               <id>MIT</id>
             </license>
           </licenses>
@@ -243,31 +243,31 @@
         </properties>
       </releaseNotes>
     </component>
-    <manufacture>
+    <manufacture bom-ref="OrganizationalEntity_cdx_bom_manufacture">
       <name>CycloneDX</name>
       <url>https://cyclonedx.org</url>
       <url>https://cyclonedx.org/docs</url>
-      <contact>
+      <contact bom-ref="OrganizationalContact_ano_bom_manufacture">
         <name>A N Other</name>
         <email>someone@somewhere.tld</email>
         <phone>+44 (0)1234 567890</phone>
       </contact>
-      <contact>
+      <contact bom-ref="OrganizationalContact_ph_bom_manufacture">
         <name>Paul Horton</name>
         <email>paul.horton@owasp.org</email>
       </contact>
     </manufacture>
-    <supplier>
+    <supplier bom-ref="OrganizationalEntity_cd_x_bom_supplier">
       <name>Cyclone DX</name>
       <url>https://cyclonedx.org/</url>
-      <contact>
+      <contact bom-ref="OrganizationalContact_ano_bom_supplier">
         <name>A N Other</name>
         <email>someone@somewhere.tld</email>
         <phone>+44 (0)1234 567890</phone>
       </contact>
     </supplier>
     <licenses>
-      <license>
+      <license bom-ref="bom_license">
         <id>Apache-2.0</id>
         <text content-type="text/plain" encoding="base64">VGVzdCBjb250ZW50IC0gdGhpcyBpcyBub3QgdGhlIEFwYWNoZSAyLjAgbGljZW5zZSE=</text>
         <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>

--- a/tests/_data/snapshots/get_bom_just_complete_metadata-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_just_complete_metadata-1.6.json.bin
@@ -7,11 +7,13 @@
   "metadata": {
     "authors": [
       {
+        "bom-ref": "OrganizationalContact_ano_bom_authors",
         "email": "someone@somewhere.tld",
         "name": "A N Other",
         "phone": "+44 (0)1234 567890"
       },
       {
+        "bom-ref": "OrganizationalContact_ph_bom_authors",
         "email": "paul.horton@owasp.org",
         "name": "Paul Horton"
       }
@@ -26,6 +28,7 @@
           "licenses": [
             {
               "license": {
+                "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
                 "id": "MIT"
               }
             }
@@ -91,24 +94,29 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-specific-bom-ref-for-dings_license",
             "id": "MIT"
           }
         }
       ],
       "manufacturer": {
         "address": {
+          "bom-ref": "PostalAddress_1_rc_manufacturer",
           "country": "GB",
           "locality": "Cheshire",
           "region": "England",
           "streetAddress": "100 Main Street"
         },
+        "bom-ref": "OrganizationalEntity_cdx_rc_manufacturer",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_rc_manufacturer",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_rc_manufacturer",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }
@@ -128,6 +136,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ccc8d7ee-4b9c-4750-aee0-a72585152291_license",
                   "id": "MIT"
                 }
               }
@@ -143,6 +152,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "8a3893b3-9923-4adb-a1d3-47456636ba0a_license",
                   "id": "MIT"
                 }
               }
@@ -165,6 +175,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "28b2d8ce-def0-446f-a221-58dee0b44acc_license",
                   "id": "MIT"
                 }
               }
@@ -221,6 +232,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ded1d73e-1fca-4302-b520-f1bc53979958_license",
                   "id": "MIT"
                 }
               }
@@ -332,18 +344,22 @@
       "scope": "required",
       "supplier": {
         "address": {
+          "bom-ref": "PostalAddress_1_my-specific-bom-ref-for-dings",
           "country": "GB",
           "locality": "Cheshire",
           "region": "England",
           "streetAddress": "100 Main Street"
         },
+        "bom-ref": "OrganizationalEntity_cdx_my-specific-bom-ref-for-dings",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_my-specific-bom-ref-for-dings",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_my-specific-bom-ref-for-dings",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }
@@ -370,6 +386,7 @@
     "licenses": [
       {
         "license": {
+          "bom-ref": "bom_license",
           "id": "Apache-2.0",
           "text": {
             "content": "VGVzdCBjb250ZW50IC0gdGhpcyBpcyBub3QgdGhlIEFwYWNoZSAyLjAgbGljZW5zZSE=",
@@ -387,18 +404,22 @@
     ],
     "manufacture": {
       "address": {
+        "bom-ref": "PostalAddress_1_bom_manufacture",
         "country": "GB",
         "locality": "Cheshire",
         "region": "England",
         "streetAddress": "100 Main Street"
       },
+      "bom-ref": "OrganizationalEntity_cdx_bom_manufacture",
       "contact": [
         {
+          "bom-ref": "OrganizationalContact_ano_bom_manufacture",
           "email": "someone@somewhere.tld",
           "name": "A N Other",
           "phone": "+44 (0)1234 567890"
         },
         {
+          "bom-ref": "OrganizationalContact_ph_bom_manufacture",
           "email": "paul.horton@owasp.org",
           "name": "Paul Horton"
         }
@@ -421,6 +442,7 @@
     ],
     "supplier": {
       "address": {
+        "bom-ref": "PostalAddress_2_bom_supplier",
         "country": "US",
         "locality": "Austin",
         "postOfficeBoxNumber": "105a",
@@ -428,8 +450,10 @@
         "region": "Texas",
         "streetAddress": "100 Yee-Ha Street"
       },
+      "bom-ref": "OrganizationalEntity_cd_x_bom_supplier",
       "contact": [
         {
+          "bom-ref": "OrganizationalContact_ano_bom_supplier",
           "email": "someone@somewhere.tld",
           "name": "A N Other",
           "phone": "+44 (0)1234 567890"

--- a/tests/_data/snapshots/get_bom_just_complete_metadata-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_just_complete_metadata-1.6.xml.bin
@@ -8,20 +8,20 @@
       </lifecycle>
     </lifecycles>
     <authors>
-      <author>
+      <author bom-ref="OrganizationalContact_ano_bom_authors">
         <name>A N Other</name>
         <email>someone@somewhere.tld</email>
         <phone>+44 (0)1234 567890</phone>
       </author>
-      <author>
+      <author bom-ref="OrganizationalContact_ph_bom_authors">
         <name>Paul Horton</name>
         <email>paul.horton@owasp.org</email>
       </author>
     </authors>
     <component type="library" bom-ref="my-specific-bom-ref-for-dings">
-      <supplier>
+      <supplier bom-ref="OrganizationalEntity_cdx_my-specific-bom-ref-for-dings">
         <name>CycloneDX</name>
-        <address>
+        <address bom-ref="PostalAddress_1_my-specific-bom-ref-for-dings">
           <country>GB</country>
           <region>England</region>
           <locality>Cheshire</locality>
@@ -29,19 +29,19 @@
         </address>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_my-specific-bom-ref-for-dings">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_my-specific-bom-ref-for-dings">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
       </supplier>
-      <manufacturer>
+      <manufacturer bom-ref="OrganizationalEntity_cdx_rc_manufacturer">
         <name>CycloneDX</name>
-        <address>
+        <address bom-ref="PostalAddress_1_rc_manufacturer">
           <country>GB</country>
           <region>England</region>
           <locality>Cheshire</locality>
@@ -49,12 +49,12 @@
         </address>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_rc_manufacturer">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_rc_manufacturer">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -66,7 +66,7 @@
       <description>This component is awesome</description>
       <scope>required</scope>
       <licenses>
-        <license>
+        <license bom-ref="my-specific-bom-ref-for-dings_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -83,7 +83,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ccc8d7ee-4b9c-4750-aee0-a72585152291_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -93,7 +93,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="8a3893b3-9923-4adb-a1d3-47456636ba0a_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -105,7 +105,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="28b2d8ce-def0-446f-a221-58dee0b44acc_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -135,7 +135,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ded1d73e-1fca-4302-b520-f1bc53979958_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -194,7 +194,7 @@
           <name>setuptools</name>
           <version>50.3.2</version>
           <licenses>
-            <license>
+            <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
               <id>MIT</id>
             </license>
           </licenses>
@@ -269,9 +269,9 @@
         </properties>
       </releaseNotes>
     </component>
-    <manufacture>
+    <manufacture bom-ref="OrganizationalEntity_cdx_bom_manufacture">
       <name>CycloneDX</name>
-      <address>
+      <address bom-ref="PostalAddress_1_bom_manufacture">
         <country>GB</country>
         <region>England</region>
         <locality>Cheshire</locality>
@@ -279,19 +279,19 @@
       </address>
       <url>https://cyclonedx.org</url>
       <url>https://cyclonedx.org/docs</url>
-      <contact>
+      <contact bom-ref="OrganizationalContact_ano_bom_manufacture">
         <name>A N Other</name>
         <email>someone@somewhere.tld</email>
         <phone>+44 (0)1234 567890</phone>
       </contact>
-      <contact>
+      <contact bom-ref="OrganizationalContact_ph_bom_manufacture">
         <name>Paul Horton</name>
         <email>paul.horton@owasp.org</email>
       </contact>
     </manufacture>
-    <supplier>
+    <supplier bom-ref="OrganizationalEntity_cd_x_bom_supplier">
       <name>Cyclone DX</name>
-      <address>
+      <address bom-ref="PostalAddress_2_bom_supplier">
         <country>US</country>
         <region>Texas</region>
         <locality>Austin</locality>
@@ -300,14 +300,14 @@
         <streetAddress>100 Yee-Ha Street</streetAddress>
       </address>
       <url>https://cyclonedx.org/</url>
-      <contact>
+      <contact bom-ref="OrganizationalContact_ano_bom_supplier">
         <name>A N Other</name>
         <email>someone@somewhere.tld</email>
         <phone>+44 (0)1234 567890</phone>
       </contact>
     </supplier>
     <licenses>
-      <license>
+      <license bom-ref="bom_license">
         <id>Apache-2.0</id>
         <text content-type="text/plain" encoding="base64">VGVzdCBjb250ZW50IC0gdGhpcyBpcyBub3QgdGhlIEFwYWNoZSAyLjAgbGljZW5zZSE=</text>
         <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>

--- a/tests/_data/snapshots/get_bom_with_component_evidence-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_evidence-1.5.json.bin
@@ -45,6 +45,7 @@
         "licenses": [
           {
             "license": {
+              "bom-ref": "evidence_license",
               "id": "MIT"
             }
           }
@@ -58,6 +59,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "c_license",
             "id": "MIT"
           }
         }
@@ -85,6 +87,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "root_c_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_evidence-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_evidence-1.5.xml.bin
@@ -12,7 +12,7 @@
     <component type="application" bom-ref="myApp">
       <name>root-component</name>
       <licenses>
-        <license>
+        <license bom-ref="root_c_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -24,7 +24,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="c_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -66,7 +66,7 @@
           </frames>
         </callstack>
         <licenses>
-          <license>
+          <license bom-ref="evidence_license">
             <id>MIT</id>
           </license>
         </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_evidence-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_evidence-1.6.json.bin
@@ -63,6 +63,7 @@
         "licenses": [
           {
             "license": {
+              "bom-ref": "evidence_license",
               "id": "MIT"
             }
           }
@@ -80,6 +81,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "c_license",
             "id": "MIT"
           }
         }
@@ -107,6 +109,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "root_c_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_evidence-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_evidence-1.6.xml.bin
@@ -12,7 +12,7 @@
     <component type="application" bom-ref="myApp">
       <name>root-component</name>
       <licenses>
-        <license>
+        <license bom-ref="root_c_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -24,7 +24,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="c_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -86,7 +86,7 @@
           </frames>
         </callstack>
         <licenses>
-          <license>
+          <license bom-ref="evidence_license">
             <id>MIT</id>
           </license>
         </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.5.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.6.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_basic-1.6.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.5.json.bin
@@ -10,6 +10,7 @@
           "licenses": [
             {
               "license": {
+                "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
                 "id": "MIT"
               }
             }
@@ -75,6 +76,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-specific-bom-ref-for-dings_license",
             "id": "MIT"
           }
         }
@@ -88,6 +90,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ccc8d7ee-4b9c-4750-aee0-a72585152291_license",
                   "id": "MIT"
                 }
               }
@@ -103,6 +106,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "8a3893b3-9923-4adb-a1d3-47456636ba0a_license",
                   "id": "MIT"
                 }
               }
@@ -125,6 +129,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "28b2d8ce-def0-446f-a221-58dee0b44acc_license",
                   "id": "MIT"
                 }
               }
@@ -181,6 +186,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ded1d73e-1fca-4302-b520-f1bc53979958_license",
                   "id": "MIT"
                 }
               }
@@ -291,13 +297,16 @@
       },
       "scope": "required",
       "supplier": {
+        "bom-ref": "OrganizationalEntity_cdx_my-specific-bom-ref-for-dings",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_my-specific-bom-ref-for-dings",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_my-specific-bom-ref-for-dings",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.5.xml.bin
@@ -5,16 +5,16 @@
   </metadata>
   <components>
     <component type="library" bom-ref="my-specific-bom-ref-for-dings">
-      <supplier>
+      <supplier bom-ref="OrganizationalEntity_cdx_my-specific-bom-ref-for-dings">
         <name>CycloneDX</name>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_my-specific-bom-ref-for-dings">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_my-specific-bom-ref-for-dings">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -26,7 +26,7 @@
       <description>This component is awesome</description>
       <scope>required</scope>
       <licenses>
-        <license>
+        <license bom-ref="my-specific-bom-ref-for-dings_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -43,7 +43,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ccc8d7ee-4b9c-4750-aee0-a72585152291_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -53,7 +53,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="8a3893b3-9923-4adb-a1d3-47456636ba0a_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -65,7 +65,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="28b2d8ce-def0-446f-a221-58dee0b44acc_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -95,7 +95,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ded1d73e-1fca-4302-b520-f1bc53979958_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -154,7 +154,7 @@
           <name>setuptools</name>
           <version>50.3.2</version>
           <licenses>
-            <license>
+            <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
               <id>MIT</id>
             </license>
           </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.6.json.bin
@@ -10,6 +10,7 @@
           "licenses": [
             {
               "license": {
+                "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
                 "id": "MIT"
               }
             }
@@ -75,6 +76,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-specific-bom-ref-for-dings_license",
             "id": "MIT"
           }
         }
@@ -88,6 +90,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ccc8d7ee-4b9c-4750-aee0-a72585152291_license",
                   "id": "MIT"
                 }
               }
@@ -103,6 +106,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "8a3893b3-9923-4adb-a1d3-47456636ba0a_license",
                   "id": "MIT"
                 }
               }
@@ -125,6 +129,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "28b2d8ce-def0-446f-a221-58dee0b44acc_license",
                   "id": "MIT"
                 }
               }
@@ -181,6 +186,7 @@
             "licenses": [
               {
                 "license": {
+                  "bom-ref": "ded1d73e-1fca-4302-b520-f1bc53979958_license",
                   "id": "MIT"
                 }
               }
@@ -292,18 +298,22 @@
       "scope": "required",
       "supplier": {
         "address": {
+          "bom-ref": "PostalAddress_1_my-specific-bom-ref-for-dings",
           "country": "GB",
           "locality": "Cheshire",
           "region": "England",
           "streetAddress": "100 Main Street"
         },
+        "bom-ref": "OrganizationalEntity_cdx_my-specific-bom-ref-for-dings",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_my-specific-bom-ref-for-dings",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_my-specific-bom-ref-for-dings",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_complete-1.6.xml.bin
@@ -5,9 +5,9 @@
   </metadata>
   <components>
     <component type="library" bom-ref="my-specific-bom-ref-for-dings">
-      <supplier>
+      <supplier bom-ref="OrganizationalEntity_cdx_my-specific-bom-ref-for-dings">
         <name>CycloneDX</name>
-        <address>
+        <address bom-ref="PostalAddress_1_my-specific-bom-ref-for-dings">
           <country>GB</country>
           <region>England</region>
           <locality>Cheshire</locality>
@@ -15,12 +15,12 @@
         </address>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_my-specific-bom-ref-for-dings">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_my-specific-bom-ref-for-dings">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -32,7 +32,7 @@
       <description>This component is awesome</description>
       <scope>required</scope>
       <licenses>
-        <license>
+        <license bom-ref="my-specific-bom-ref-for-dings_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -49,7 +49,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ccc8d7ee-4b9c-4750-aee0-a72585152291_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -59,7 +59,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="8a3893b3-9923-4adb-a1d3-47456636ba0a_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -71,7 +71,7 @@
             <author>Test Author</author>
             <name>setuptools</name>
             <licenses>
-              <license>
+              <license bom-ref="28b2d8ce-def0-446f-a221-58dee0b44acc_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -101,7 +101,7 @@
             <name>setuptools</name>
             <version>50.3.2</version>
             <licenses>
-              <license>
+              <license bom-ref="ded1d73e-1fca-4302-b520-f1bc53979958_license">
                 <id>MIT</id>
               </license>
             </licenses>
@@ -160,7 +160,7 @@
           <name>setuptools</name>
           <version>50.3.2</version>
           <licenses>
-            <license>
+            <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
               <id>MIT</id>
             </license>
           </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.5.xml.bin
@@ -8,7 +8,7 @@
       <author>Test Author</author>
       <name>setuptools</name>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.6.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_no_component_version-1.6.xml.bin
@@ -8,7 +8,7 @@
       <author>Test Author</author>
       <name>setuptools</name>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.5.json.bin
@@ -7,6 +7,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.5.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.6.json.bin
@@ -7,6 +7,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_cpe-1.6.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.5.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.6.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_release_notes-1.6.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.5.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.6.json.bin
@@ -4,11 +4,13 @@
       "author": "Test Author",
       "authors": [
         {
+          "bom-ref": "OrganizationalContact_ano_pkg:pypi/setuptools@50.3.2?extension=tar.gz_authors2",
           "email": "someone@somewhere.tld",
           "name": "A N Other",
           "phone": "+44 (0)1234 567890"
         },
         {
+          "bom-ref": "OrganizationalContact_ph_pkg:pypi/setuptools@50.3.2?extension=tar.gz_authors1",
           "email": "paul.horton@owasp.org",
           "name": "Paul Horton"
         }
@@ -17,24 +19,29 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }
       ],
       "manufacturer": {
         "address": {
+          "bom-ref": "PostalAddress_1_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer",
           "country": "GB",
           "locality": "Cheshire",
           "region": "England",
           "streetAddress": "100 Main Street"
         },
+        "bom-ref": "OrganizationalEntity_cdx_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_v16_fields-1.6.xml.bin
@@ -5,9 +5,9 @@
   </metadata>
   <components>
     <component type="library" bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz">
-      <manufacturer>
+      <manufacturer bom-ref="OrganizationalEntity_cdx_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer">
         <name>CycloneDX</name>
-        <address>
+        <address bom-ref="PostalAddress_1_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer">
           <country>GB</country>
           <region>England</region>
           <locality>Cheshire</locality>
@@ -15,23 +15,23 @@
         </address>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_pkg:pypi/setuptools@50.3.2?extension=tar.gz_manufacturer">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
       </manufacturer>
       <authors>
-        <author>
+        <author bom-ref="OrganizationalContact_ano_pkg:pypi/setuptools@50.3.2?extension=tar.gz_authors2">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </author>
-        <author>
+        <author bom-ref="OrganizationalContact_ph_pkg:pypi/setuptools@50.3.2?extension=tar.gz_authors1">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </author>
@@ -40,7 +40,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }
@@ -72,6 +73,7 @@
       "credits": {
         "individuals": [
           {
+            "bom-ref": "OrganizationalContact_ano_vuln_credits_ind",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
@@ -79,13 +81,16 @@
         ],
         "organizations": [
           {
+            "bom-ref": "OrganizationalEntity_cdx_vuln_credits_org",
             "contact": [
               {
+                "bom-ref": "OrganizationalContact_ano_vuln_credits_org",
                 "email": "someone@somewhere.tld",
                 "name": "A N Other",
                 "phone": "+44 (0)1234 567890"
               },
               {
+                "bom-ref": "OrganizationalContact_ph_vuln_credits_org",
                 "email": "paul.horton@owasp.org",
                 "name": "Paul Horton"
               }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.5.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -84,23 +84,23 @@
       <updated>2021-09-03T10:50:42.051979+00:00</updated>
       <credits>
         <organizations>
-          <organization>
+          <organization bom-ref="OrganizationalEntity_cdx_vuln_credits_org">
             <name>CycloneDX</name>
             <url>https://cyclonedx.org</url>
             <url>https://cyclonedx.org/docs</url>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ano_vuln_credits_org">
               <name>A N Other</name>
               <email>someone@somewhere.tld</email>
               <phone>+44 (0)1234 567890</phone>
             </contact>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ph_vuln_credits_org">
               <name>Paul Horton</name>
               <email>paul.horton@owasp.org</email>
             </contact>
           </organization>
         </organizations>
         <individuals>
-          <individual>
+          <individual bom-ref="OrganizationalContact_ano_vuln_credits_ind">
             <name>A N Other</name>
             <email>someone@somewhere.tld</email>
             <phone>+44 (0)1234 567890</phone>

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }
@@ -72,6 +73,7 @@
       "credits": {
         "individuals": [
           {
+            "bom-ref": "OrganizationalContact_ano_vuln_credits_ind",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
@@ -80,18 +82,22 @@
         "organizations": [
           {
             "address": {
+              "bom-ref": "PostalAddress_1_vuln_credits_org",
               "country": "GB",
               "locality": "Cheshire",
               "region": "England",
               "streetAddress": "100 Main Street"
             },
+            "bom-ref": "OrganizationalEntity_cdx_vuln_credits_org",
             "contact": [
               {
+                "bom-ref": "OrganizationalContact_ano_vuln_credits_org",
                 "email": "someone@somewhere.tld",
                 "name": "A N Other",
                 "phone": "+44 (0)1234 567890"
               },
               {
+                "bom-ref": "OrganizationalContact_ph_vuln_credits_org",
                 "email": "paul.horton@owasp.org",
                 "name": "Paul Horton"
               }

--- a/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_component_setuptools_with_vulnerability-1.6.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>
@@ -84,9 +84,9 @@
       <updated>2021-09-03T10:50:42.051979+00:00</updated>
       <credits>
         <organizations>
-          <organization>
+          <organization bom-ref="OrganizationalEntity_cdx_vuln_credits_org">
             <name>CycloneDX</name>
-            <address>
+            <address bom-ref="PostalAddress_1_vuln_credits_org">
               <country>GB</country>
               <region>England</region>
               <locality>Cheshire</locality>
@@ -94,19 +94,19 @@
             </address>
             <url>https://cyclonedx.org</url>
             <url>https://cyclonedx.org/docs</url>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ano_vuln_credits_org">
               <name>A N Other</name>
               <email>someone@somewhere.tld</email>
               <phone>+44 (0)1234 567890</phone>
             </contact>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ph_vuln_credits_org">
               <name>Paul Horton</name>
               <email>paul.horton@owasp.org</email>
             </contact>
           </organization>
         </organizations>
         <individuals>
-          <individual>
+          <individual bom-ref="OrganizationalContact_ano_vuln_credits_ind">
             <name>A N Other</name>
             <email>someone@somewhere.tld</email>
             <phone>+44 (0)1234 567890</phone>

--- a/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "setuptools_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.5.xml.bin
@@ -12,7 +12,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="setuptools_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.6.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "setuptools_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_hanging-1.6.xml.bin
@@ -12,7 +12,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="setuptools_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_dependencies_valid-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_valid-1.5.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_dependencies_valid-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_valid-1.5.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_dependencies_valid-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_valid-1.6.json.bin
@@ -6,6 +6,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_dependencies_valid-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_dependencies_valid-1.6.xml.bin
@@ -9,7 +9,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.5.json.bin
@@ -5,6 +5,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "C2_license",
             "id": "Apache-2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
@@ -17,6 +18,7 @@
       "bom-ref": "C1",
       "licenses": [
         {
+          "bom-ref": "C1_license",
           "expression": "Apache-2.0 OR MIT"
         }
       ],
@@ -28,6 +30,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "c-with-name_license_2",
             "name": "some additional",
             "text": {
               "content": "this is additional license text",
@@ -37,6 +40,7 @@
         },
         {
           "license": {
+            "bom-ref": "c-with-name_license_1",
             "name": "some commercial license",
             "text": {
               "content": "this is a license text",
@@ -78,6 +82,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "root_component_license",
             "name": "proprietary"
           }
         }
@@ -88,6 +93,7 @@
     "licenses": [
       {
         "license": {
+          "bom-ref": "bom_license",
           "id": "CC-BY-1.0"
         }
       }
@@ -111,6 +117,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "S2_license",
             "id": "Apache-2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
@@ -122,6 +129,7 @@
       "bom-ref": "S1",
       "licenses": [
         {
+          "bom-ref": "S1_license",
           "expression": "Apache-2.0 OR MIT"
         }
       ],
@@ -132,6 +140,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "S3_license2",
             "name": "some additional",
             "text": {
               "content": "this is additional license text",
@@ -141,6 +150,7 @@
         },
         {
           "license": {
+            "bom-ref": "S3_license1",
             "name": "some commercial license",
             "text": {
               "content": "this is a license text",

--- a/tests/_data/snapshots/get_bom_with_licenses-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.5.xml.bin
@@ -5,13 +5,13 @@
     <component type="application" bom-ref="my-app">
       <name>app</name>
       <licenses>
-        <license>
+        <license bom-ref="root_component_license">
           <name>proprietary</name>
         </license>
       </licenses>
     </component>
     <licenses>
-      <license>
+      <license bom-ref="bom_license">
         <id>CC-BY-1.0</id>
       </license>
     </licenses>
@@ -20,7 +20,7 @@
     <component type="library" bom-ref="C2">
       <name>c-with-SPDX</name>
       <licenses>
-        <license>
+        <license bom-ref="C2_license">
           <id>Apache-2.0</id>
           <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
@@ -29,17 +29,17 @@
     <component type="library" bom-ref="C1">
       <name>c-with-expression</name>
       <licenses>
-        <expression>Apache-2.0 OR MIT</expression>
+        <expression bom-ref="C1_license">Apache-2.0 OR MIT</expression>
       </licenses>
     </component>
     <component type="library" bom-ref="C3">
       <name>c-with-name</name>
       <licenses>
-        <license>
+        <license bom-ref="c-with-name_license_2">
           <name>some additional</name>
           <text content-type="text/plain">this is additional license text</text>
         </license>
-        <license>
+        <license bom-ref="c-with-name_license_1">
           <name>some commercial license</name>
           <text content-type="text/plain">this is a license text</text>
         </license>
@@ -50,7 +50,7 @@
     <service bom-ref="S2">
       <name>s-with-SPDX</name>
       <licenses>
-        <license>
+        <license bom-ref="S2_license">
           <id>Apache-2.0</id>
           <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
@@ -59,17 +59,17 @@
     <service bom-ref="S1">
       <name>s-with-expression</name>
       <licenses>
-        <expression>Apache-2.0 OR MIT</expression>
+        <expression bom-ref="S1_license">Apache-2.0 OR MIT</expression>
       </licenses>
     </service>
     <service bom-ref="S3">
       <name>s-with-name</name>
       <licenses>
-        <license>
+        <license bom-ref="S3_license2">
           <name>some additional</name>
           <text content-type="text/plain">this is additional license text</text>
         </license>
-        <license>
+        <license bom-ref="S3_license1">
           <name>some commercial license</name>
           <text content-type="text/plain">this is a license text</text>
         </license>

--- a/tests/_data/snapshots/get_bom_with_licenses-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.6.json.bin
@@ -6,6 +6,7 @@
         {
           "license": {
             "acknowledgement": "concluded",
+            "bom-ref": "C2_license",
             "id": "Apache-2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
@@ -19,6 +20,7 @@
       "licenses": [
         {
           "acknowledgement": "concluded",
+          "bom-ref": "C1_license",
           "expression": "Apache-2.0 OR MIT"
         }
       ],
@@ -30,6 +32,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "c-with-name_license_2",
             "name": "some additional",
             "text": {
               "content": "this is additional license text",
@@ -39,6 +42,7 @@
         },
         {
           "license": {
+            "bom-ref": "c-with-name_license_1",
             "name": "some commercial license",
             "text": {
               "content": "this is a license text",
@@ -80,6 +84,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "root_component_license",
             "name": "proprietary"
           }
         }
@@ -90,6 +95,7 @@
     "licenses": [
       {
         "license": {
+          "bom-ref": "bom_license",
           "id": "CC-BY-1.0"
         }
       }
@@ -114,6 +120,7 @@
         {
           "license": {
             "acknowledgement": "declared",
+            "bom-ref": "S2_license",
             "id": "Apache-2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
           }
@@ -126,6 +133,7 @@
       "licenses": [
         {
           "acknowledgement": "declared",
+          "bom-ref": "S1_license",
           "expression": "Apache-2.0 OR MIT"
         }
       ],
@@ -136,6 +144,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "S3_license2",
             "name": "some additional",
             "text": {
               "content": "this is additional license text",
@@ -145,6 +154,7 @@
         },
         {
           "license": {
+            "bom-ref": "S3_license1",
             "name": "some commercial license",
             "text": {
               "content": "this is a license text",

--- a/tests/_data/snapshots/get_bom_with_licenses-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_licenses-1.6.xml.bin
@@ -5,13 +5,13 @@
     <component type="application" bom-ref="my-app">
       <name>app</name>
       <licenses>
-        <license>
+        <license bom-ref="root_component_license">
           <name>proprietary</name>
         </license>
       </licenses>
     </component>
     <licenses>
-      <license>
+      <license bom-ref="bom_license">
         <id>CC-BY-1.0</id>
       </license>
     </licenses>
@@ -20,7 +20,7 @@
     <component type="library" bom-ref="C2">
       <name>c-with-SPDX</name>
       <licenses>
-        <license acknowledgement="concluded">
+        <license bom-ref="C2_license" acknowledgement="concluded">
           <id>Apache-2.0</id>
           <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
@@ -29,17 +29,17 @@
     <component type="library" bom-ref="C1">
       <name>c-with-expression</name>
       <licenses>
-        <expression acknowledgement="concluded">Apache-2.0 OR MIT</expression>
+        <expression bom-ref="C1_license" acknowledgement="concluded">Apache-2.0 OR MIT</expression>
       </licenses>
     </component>
     <component type="library" bom-ref="C3">
       <name>c-with-name</name>
       <licenses>
-        <license>
+        <license bom-ref="c-with-name_license_2">
           <name>some additional</name>
           <text content-type="text/plain">this is additional license text</text>
         </license>
-        <license>
+        <license bom-ref="c-with-name_license_1">
           <name>some commercial license</name>
           <text content-type="text/plain">this is a license text</text>
         </license>
@@ -50,7 +50,7 @@
     <service bom-ref="S2">
       <name>s-with-SPDX</name>
       <licenses>
-        <license acknowledgement="declared">
+        <license bom-ref="S2_license" acknowledgement="declared">
           <id>Apache-2.0</id>
           <url>https://www.apache.org/licenses/LICENSE-2.0.html</url>
         </license>
@@ -59,17 +59,17 @@
     <service bom-ref="S1">
       <name>s-with-expression</name>
       <licenses>
-        <expression acknowledgement="declared">Apache-2.0 OR MIT</expression>
+        <expression bom-ref="S1_license" acknowledgement="declared">Apache-2.0 OR MIT</expression>
       </licenses>
     </service>
     <service bom-ref="S3">
       <name>s-with-name</name>
       <licenses>
-        <license>
+        <license bom-ref="S3_license2">
           <name>some additional</name>
           <text content-type="text/plain">this is additional license text</text>
         </license>
-        <license>
+        <license bom-ref="S3_license1">
           <name>some commercial license</name>
           <text content-type="text/plain">this is a license text</text>
         </license>

--- a/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.5.json.bin
@@ -45,6 +45,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.5.xml.bin
@@ -7,7 +7,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.6.json.bin
@@ -45,6 +45,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "pkg:pypi/setuptools@50.3.2?extension=tar.gz_license",
             "id": "MIT"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_metadata_component_and_dependencies-1.6.xml.bin
@@ -7,7 +7,7 @@
       <name>setuptools</name>
       <version>50.3.2</version>
       <licenses>
-        <license>
+        <license bom-ref="pkg:pypi/setuptools@50.3.2?extension=tar.gz_license">
           <id>MIT</id>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_multiple_licenses-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_multiple_licenses-1.5.json.bin
@@ -5,11 +5,13 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-compo_license_mit",
             "id": "MIT"
           }
         },
         {
           "license": {
+            "bom-ref": "my-compo_license_foo",
             "name": "foo license"
           }
         }
@@ -35,11 +37,13 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-app_license_mit",
             "id": "MIT"
           }
         },
         {
           "license": {
+            "bom-ref": "my-app_license_foo",
             "name": "foo license"
           }
         }
@@ -50,11 +54,13 @@
     "licenses": [
       {
         "license": {
+          "bom-ref": "bom_license_mit",
           "id": "MIT"
         }
       },
       {
         "license": {
+          "bom-ref": "bom_license_foo",
           "name": "foo license"
         }
       }
@@ -78,11 +84,13 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-serv_license_mit",
             "id": "MIT"
           }
         },
         {
           "license": {
+            "bom-ref": "my-serv_license_foo",
             "name": "foo license"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_multiple_licenses-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_multiple_licenses-1.5.xml.bin
@@ -5,19 +5,19 @@
     <component type="application" bom-ref="my-app">
       <name>app</name>
       <licenses>
-        <license>
+        <license bom-ref="my-app_license_mit">
           <id>MIT</id>
         </license>
-        <license>
+        <license bom-ref="my-app_license_foo">
           <name>foo license</name>
         </license>
       </licenses>
     </component>
     <licenses>
-      <license>
+      <license bom-ref="bom_license_mit">
         <id>MIT</id>
       </license>
-      <license>
+      <license bom-ref="bom_license_foo">
         <name>foo license</name>
       </license>
     </licenses>
@@ -26,10 +26,10 @@
     <component type="library" bom-ref="my-compo">
       <name>comp</name>
       <licenses>
-        <license>
+        <license bom-ref="my-compo_license_mit">
           <id>MIT</id>
         </license>
-        <license>
+        <license bom-ref="my-compo_license_foo">
           <name>foo license</name>
         </license>
       </licenses>
@@ -39,10 +39,10 @@
     <service bom-ref="my-serv">
       <name>serv</name>
       <licenses>
-        <license>
+        <license bom-ref="my-serv_license_mit">
           <id>MIT</id>
         </license>
-        <license>
+        <license bom-ref="my-serv_license_foo">
           <name>foo license</name>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_multiple_licenses-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_multiple_licenses-1.6.json.bin
@@ -5,11 +5,13 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-compo_license_mit",
             "id": "MIT"
           }
         },
         {
           "license": {
+            "bom-ref": "my-compo_license_foo",
             "name": "foo license"
           }
         }
@@ -35,11 +37,13 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-app_license_mit",
             "id": "MIT"
           }
         },
         {
           "license": {
+            "bom-ref": "my-app_license_foo",
             "name": "foo license"
           }
         }
@@ -50,11 +54,13 @@
     "licenses": [
       {
         "license": {
+          "bom-ref": "bom_license_mit",
           "id": "MIT"
         }
       },
       {
         "license": {
+          "bom-ref": "bom_license_foo",
           "name": "foo license"
         }
       }
@@ -78,11 +84,13 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "my-serv_license_mit",
             "id": "MIT"
           }
         },
         {
           "license": {
+            "bom-ref": "my-serv_license_foo",
             "name": "foo license"
           }
         }

--- a/tests/_data/snapshots/get_bom_with_multiple_licenses-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_multiple_licenses-1.6.xml.bin
@@ -5,19 +5,19 @@
     <component type="application" bom-ref="my-app">
       <name>app</name>
       <licenses>
-        <license>
+        <license bom-ref="my-app_license_mit">
           <id>MIT</id>
         </license>
-        <license>
+        <license bom-ref="my-app_license_foo">
           <name>foo license</name>
         </license>
       </licenses>
     </component>
     <licenses>
-      <license>
+      <license bom-ref="bom_license_mit">
         <id>MIT</id>
       </license>
-      <license>
+      <license bom-ref="bom_license_foo">
         <name>foo license</name>
       </license>
     </licenses>
@@ -26,10 +26,10 @@
     <component type="library" bom-ref="my-compo">
       <name>comp</name>
       <licenses>
-        <license>
+        <license bom-ref="my-compo_license_mit">
           <id>MIT</id>
         </license>
-        <license>
+        <license bom-ref="my-compo_license_foo">
           <name>foo license</name>
         </license>
       </licenses>
@@ -39,10 +39,10 @@
     <service bom-ref="my-serv">
       <name>serv</name>
       <licenses>
-        <license>
+        <license bom-ref="my-serv_license_mit">
           <id>MIT</id>
         </license>
-        <license>
+        <license bom-ref="my-serv_license_foo">
           <name>foo license</name>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_nested_services-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_nested_services-1.5.json.bin
@@ -62,6 +62,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "service_license",
             "name": "Commercial"
           }
         }
@@ -78,13 +79,16 @@
         }
       ],
       "provider": {
+        "bom-ref": "OrganizationalEntity_cdx_s1",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_s1",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_s1",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }
@@ -161,13 +165,16 @@
           "group": "no-group",
           "name": "second-nested-service",
           "provider": {
+            "bom-ref": "OrganizationalEntity_cdx_s2",
             "contact": [
               {
+                "bom-ref": "OrganizationalContact_ano_s2",
                 "email": "someone@somewhere.tld",
                 "name": "A N Other",
                 "phone": "+44 (0)1234 567890"
               },
               {
+                "bom-ref": "OrganizationalContact_ph_s2",
                 "email": "paul.horton@owasp.org",
                 "name": "Paul Horton"
               }
@@ -198,13 +205,16 @@
           "group": "what-group",
           "name": "yet-another-nested-service",
           "provider": {
+            "bom-ref": "OrganizationalEntity_cdx_s3",
             "contact": [
               {
+                "bom-ref": "OrganizationalContact_ano_s3",
                 "email": "someone@somewhere.tld",
                 "name": "A N Other",
                 "phone": "+44 (0)1234 567890"
               },
               {
+                "bom-ref": "OrganizationalContact_ph_s3",
                 "email": "paul.horton@owasp.org",
                 "name": "Paul Horton"
               }

--- a/tests/_data/snapshots/get_bom_with_nested_services-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_nested_services-1.5.xml.bin
@@ -9,16 +9,16 @@
   </metadata>
   <services>
     <service bom-ref="my-specific-bom-ref-for-my-first-service">
-      <provider>
+      <provider bom-ref="OrganizationalEntity_cdx_s1">
         <name>CycloneDX</name>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_s1">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_s1">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -37,7 +37,7 @@
         <classification flow="outbound">public</classification>
       </data>
       <licenses>
-        <license>
+        <license bom-ref="service_license">
           <name>Commercial</name>
         </license>
       </licenses>
@@ -56,16 +56,16 @@
       </properties>
       <services>
         <service bom-ref="my-specific-bom-ref-for-second-nested-service">
-          <provider>
+          <provider bom-ref="OrganizationalEntity_cdx_s2">
             <name>CycloneDX</name>
             <url>https://cyclonedx.org</url>
             <url>https://cyclonedx.org/docs</url>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ano_s2">
               <name>A N Other</name>
               <email>someone@somewhere.tld</email>
               <phone>+44 (0)1234 567890</phone>
             </contact>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ph_s2">
               <name>Paul Horton</name>
               <email>paul.horton@owasp.org</email>
             </contact>
@@ -129,16 +129,16 @@
       <name>my-second-service</name>
       <services>
         <service bom-ref="yet-another-nested-service">
-          <provider>
+          <provider bom-ref="OrganizationalEntity_cdx_s3">
             <name>CycloneDX</name>
             <url>https://cyclonedx.org</url>
             <url>https://cyclonedx.org/docs</url>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ano_s3">
               <name>A N Other</name>
               <email>someone@somewhere.tld</email>
               <phone>+44 (0)1234 567890</phone>
             </contact>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ph_s3">
               <name>Paul Horton</name>
               <email>paul.horton@owasp.org</email>
             </contact>

--- a/tests/_data/snapshots/get_bom_with_nested_services-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_nested_services-1.6.json.bin
@@ -62,6 +62,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "service_license",
             "name": "Commercial"
           }
         }
@@ -79,18 +80,22 @@
       ],
       "provider": {
         "address": {
+          "bom-ref": "PostalAddress_1_s1",
           "country": "GB",
           "locality": "Cheshire",
           "region": "England",
           "streetAddress": "100 Main Street"
         },
+        "bom-ref": "OrganizationalEntity_cdx_s1",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_s1",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_s1",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }
@@ -168,18 +173,22 @@
           "name": "second-nested-service",
           "provider": {
             "address": {
+              "bom-ref": "PostalAddress_1_s2",
               "country": "GB",
               "locality": "Cheshire",
               "region": "England",
               "streetAddress": "100 Main Street"
             },
+            "bom-ref": "OrganizationalEntity_cdx_s2",
             "contact": [
               {
+                "bom-ref": "OrganizationalContact_ano_s2",
                 "email": "someone@somewhere.tld",
                 "name": "A N Other",
                 "phone": "+44 (0)1234 567890"
               },
               {
+                "bom-ref": "OrganizationalContact_ph_s2",
                 "email": "paul.horton@owasp.org",
                 "name": "Paul Horton"
               }
@@ -211,18 +220,22 @@
           "name": "yet-another-nested-service",
           "provider": {
             "address": {
+              "bom-ref": "PostalAddress_1_s3",
               "country": "GB",
               "locality": "Cheshire",
               "region": "England",
               "streetAddress": "100 Main Street"
             },
+            "bom-ref": "OrganizationalEntity_cdx_s3",
             "contact": [
               {
+                "bom-ref": "OrganizationalContact_ano_s3",
                 "email": "someone@somewhere.tld",
                 "name": "A N Other",
                 "phone": "+44 (0)1234 567890"
               },
               {
+                "bom-ref": "OrganizationalContact_ph_s3",
                 "email": "paul.horton@owasp.org",
                 "name": "Paul Horton"
               }

--- a/tests/_data/snapshots/get_bom_with_nested_services-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_nested_services-1.6.xml.bin
@@ -9,9 +9,9 @@
   </metadata>
   <services>
     <service bom-ref="my-specific-bom-ref-for-my-first-service">
-      <provider>
+      <provider bom-ref="OrganizationalEntity_cdx_s1">
         <name>CycloneDX</name>
-        <address>
+        <address bom-ref="PostalAddress_1_s1">
           <country>GB</country>
           <region>England</region>
           <locality>Cheshire</locality>
@@ -19,12 +19,12 @@
         </address>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_s1">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_s1">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -43,7 +43,7 @@
         <classification flow="outbound">public</classification>
       </data>
       <licenses>
-        <license>
+        <license bom-ref="service_license">
           <name>Commercial</name>
         </license>
       </licenses>
@@ -62,9 +62,9 @@
       </properties>
       <services>
         <service bom-ref="my-specific-bom-ref-for-second-nested-service">
-          <provider>
+          <provider bom-ref="OrganizationalEntity_cdx_s2">
             <name>CycloneDX</name>
-            <address>
+            <address bom-ref="PostalAddress_1_s2">
               <country>GB</country>
               <region>England</region>
               <locality>Cheshire</locality>
@@ -72,12 +72,12 @@
             </address>
             <url>https://cyclonedx.org</url>
             <url>https://cyclonedx.org/docs</url>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ano_s2">
               <name>A N Other</name>
               <email>someone@somewhere.tld</email>
               <phone>+44 (0)1234 567890</phone>
             </contact>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ph_s2">
               <name>Paul Horton</name>
               <email>paul.horton@owasp.org</email>
             </contact>
@@ -141,9 +141,9 @@
       <name>my-second-service</name>
       <services>
         <service bom-ref="yet-another-nested-service">
-          <provider>
+          <provider bom-ref="OrganizationalEntity_cdx_s3">
             <name>CycloneDX</name>
-            <address>
+            <address bom-ref="PostalAddress_1_s3">
               <country>GB</country>
               <region>England</region>
               <locality>Cheshire</locality>
@@ -151,12 +151,12 @@
             </address>
             <url>https://cyclonedx.org</url>
             <url>https://cyclonedx.org/docs</url>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ano_s3">
               <name>A N Other</name>
               <email>someone@somewhere.tld</email>
               <phone>+44 (0)1234 567890</phone>
             </contact>
-            <contact>
+            <contact bom-ref="OrganizationalContact_ph_s3">
               <name>Paul Horton</name>
               <email>paul.horton@owasp.org</email>
             </contact>

--- a/tests/_data/snapshots/get_bom_with_services_complex-1.5.json.bin
+++ b/tests/_data/snapshots/get_bom_with_services_complex-1.5.json.bin
@@ -62,6 +62,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "service_license",
             "name": "Commercial"
           }
         }
@@ -78,13 +79,16 @@
         }
       ],
       "provider": {
+        "bom-ref": "OrganizationalEntity_cdx_s1",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_s1",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_s1",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }

--- a/tests/_data/snapshots/get_bom_with_services_complex-1.5.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_services_complex-1.5.xml.bin
@@ -9,16 +9,16 @@
   </metadata>
   <services>
     <service bom-ref="my-specific-bom-ref-for-my-first-service">
-      <provider>
+      <provider bom-ref="OrganizationalEntity_cdx_s1">
         <name>CycloneDX</name>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_s1">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_s1">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -37,7 +37,7 @@
         <classification flow="outbound">public</classification>
       </data>
       <licenses>
-        <license>
+        <license bom-ref="service_license">
           <name>Commercial</name>
         </license>
       </licenses>

--- a/tests/_data/snapshots/get_bom_with_services_complex-1.6.json.bin
+++ b/tests/_data/snapshots/get_bom_with_services_complex-1.6.json.bin
@@ -62,6 +62,7 @@
       "licenses": [
         {
           "license": {
+            "bom-ref": "service_license",
             "name": "Commercial"
           }
         }
@@ -79,18 +80,22 @@
       ],
       "provider": {
         "address": {
+          "bom-ref": "PostalAddress_1_s1",
           "country": "GB",
           "locality": "Cheshire",
           "region": "England",
           "streetAddress": "100 Main Street"
         },
+        "bom-ref": "OrganizationalEntity_cdx_s1",
         "contact": [
           {
+            "bom-ref": "OrganizationalContact_ano_s1",
             "email": "someone@somewhere.tld",
             "name": "A N Other",
             "phone": "+44 (0)1234 567890"
           },
           {
+            "bom-ref": "OrganizationalContact_ph_s1",
             "email": "paul.horton@owasp.org",
             "name": "Paul Horton"
           }

--- a/tests/_data/snapshots/get_bom_with_services_complex-1.6.xml.bin
+++ b/tests/_data/snapshots/get_bom_with_services_complex-1.6.xml.bin
@@ -9,9 +9,9 @@
   </metadata>
   <services>
     <service bom-ref="my-specific-bom-ref-for-my-first-service">
-      <provider>
+      <provider bom-ref="OrganizationalEntity_cdx_s1">
         <name>CycloneDX</name>
-        <address>
+        <address bom-ref="PostalAddress_1_s1">
           <country>GB</country>
           <region>England</region>
           <locality>Cheshire</locality>
@@ -19,12 +19,12 @@
         </address>
         <url>https://cyclonedx.org</url>
         <url>https://cyclonedx.org/docs</url>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ano_s1">
           <name>A N Other</name>
           <email>someone@somewhere.tld</email>
           <phone>+44 (0)1234 567890</phone>
         </contact>
-        <contact>
+        <contact bom-ref="OrganizationalContact_ph_s1">
           <name>Paul Horton</name>
           <email>paul.horton@owasp.org</email>
         </contact>
@@ -43,7 +43,7 @@
         <classification flow="outbound">public</classification>
       </data>
       <licenses>
-        <license>
+        <license bom-ref="service_license">
           <name>Commercial</name>
         </license>
       </licenses>

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -186,9 +186,10 @@ class TestEnumEncoding(_EnumTestCase):
     @named_data(*NAMED_OF_SV)
     def test_cases_render_valid(self, of: OutputFormat, sv: SchemaVersion, *_: Any, **__: Any) -> None:
         bom = _make_bom(components=[Component(name='dummy', type=ComponentType.LIBRARY, bom_ref='dummy', licenses=(
-            DisjunctiveLicense(name=f'att.encoding: {encoding.name}', text=AttachedText(
-                content=f'att.encoding: {encoding.name}', encoding=encoding
-            )) for encoding in Encoding
+            DisjunctiveLicense(bom_ref='dummy_license',
+                               name=f'att.encoding: {encoding.name}', text=AttachedText(
+                                   content=f'att.encoding: {encoding.name}', encoding=encoding
+                               )) for encoding in Encoding
         ))])
         super()._test_cases_render(bom, of, sv)
 


### PR DESCRIPTION
> [!NOTE]
> This is a draft, an idea.
> 
> The philosophy/contract of this library, i it's early days, was to auto-populate all bom-refs, 
> so the JSON/XML result after deserializarion might be [Bom-Link](https://cyclonedx.org/capabilities/bomlink/)-able out of the box.
> 
> Over the years, some new bom-refs were introduced, and did no longer auto-populatd (maybe they were forgotten? maybe on purpose to prevent breaking changes?)
>
> This PR is a fix to follow that contract, again. 

-----

## BREAKING change

- All known BomRefs for model classes are autopopulated when deserializing.
- All known BomRefs for model classes are properly discriminated when deserializing.


TODO / DONE
- [x] have all the existing bomRefs added to `BomRefDiscriminator.from_bom()`
  - [x] `PostalAddress`
  - [x] `Requirement`
  - [x] `Level`
  - [x] `Standard`
- [x] adjust test's models if needed

-----

- on top of #938
