### PR TITLE
fix: typing in `contrib.bom.utils.BomDependencyGraphFlatMerger`

### DIFF
--- a/cyclonedx/contrib/bom/utils.py
+++ b/cyclonedx/contrib/bom/utils.py
@@ -151,7 +151,7 @@ class BomDependencyGraphFlatMerger:
 
     @staticmethod
     def _flatten_merge(deps: Iterable[Dependency]) -> Iterable[Dependency]:
-        flat: dict[BomRef, list[BomRef]] = {}
+        flat: dict['BomRef', list['BomRef']] = {}
         todos = list(deps)
         seen: list[int] = []
         while todos:


### PR DESCRIPTION
caused by https://github.com/CycloneDX/cyclonedx-python-lib/pull/997#discussion_r3394955176