### PR TITLE
feat: `ProtocolPropertiesType` enum cases for CycloneDX 1.7

### DIFF
--- a/cyclonedx/model/crypto.py
+++ b/cyclonedx/model/crypto.py
@@ -1096,15 +1096,70 @@ class ProtocolPropertiesType(str, Enum):
         See the CycloneDX Schema for hashType: https://cyclonedx.org/docs/1.7/xml/#type_cryptoPropertiesType
     """
 
+    DTLS = 'dtls'  # since CDX1.7
+    EAP_AKA = 'eap-aka'  # since CDX1.7
+    EAP_AKA_PRIME = 'eap-aka-prime'  # since CDX1.7
+    FIVEG_AKA = '5g-aka'  # since CDX1.7
     IKE = 'ike'
     IPSEC = 'ipsec'
+    PRINS = 'prins'  # since CDX1.7
+    QUIC = 'quic'  # since CDX1.7
     SSH = 'ssh'
     SSTP = 'sstp'
     TLS = 'tls'
     WPA = 'wpa'
-
+    # --
     OTHER = 'other'
     UNKNOWN = 'unknown'
+
+
+class _ProtocolPropertiesTypeSerializationHelper(serializable.helpers.BaseHelper):
+    """  THIS CLASS IS NON-PUBLIC API  """
+
+    __CASES: dict[type[serializable.ViewType], frozenset[ProtocolPropertiesType]] = dict()
+    __CASES[SchemaVersion1Dot6] = frozenset({
+        ProtocolPropertiesType.IKE,
+        ProtocolPropertiesType.IPSEC,
+        ProtocolPropertiesType.SSH,
+        ProtocolPropertiesType.SSTP,
+        ProtocolPropertiesType.TLS,
+        ProtocolPropertiesType.WPA,
+        ProtocolPropertiesType.OTHER,
+        ProtocolPropertiesType.UNKNOWN,
+    })
+    __CASES[SchemaVersion1Dot7] = __CASES[SchemaVersion1Dot6] | {
+        ProtocolPropertiesType.DTLS,
+        ProtocolPropertiesType.EAP_AKA,
+        ProtocolPropertiesType.EAP_AKA_PRIME,
+        ProtocolPropertiesType.PRINS,
+        ProtocolPropertiesType.QUIC,
+    }
+
+    @classmethod
+    def __normalize(cls, ppt: ProtocolPropertiesType, view: type[serializable.ViewType]) -> str:
+        return (
+            ppt
+            if ppt in cls.__CASES.get(view, ())
+            else ProtocolPropertiesType.OTHER
+        ).value
+
+    @classmethod
+    def json_normalize(cls, o: Any, *,
+                       view: Optional[type[serializable.ViewType]],
+                       **__: Any) -> str:
+        assert view is not None
+        return cls.__normalize(o, view)
+
+    @classmethod
+    def xml_normalize(cls, o: Any, *,
+                      view: Optional[type[serializable.ViewType]],
+                      **__: Any) -> str:
+        assert view is not None
+        return cls.__normalize(o, view)
+
+    @classmethod
+    def deserialize(cls, o: Any) -> ProtocolPropertiesType:
+        return ProtocolPropertiesType(o)
 
 
 @serializable.serializable_class(ignore_unknown_during_deserialization=True)
@@ -1376,6 +1431,7 @@ class ProtocolProperties:
         self.crypto_refs = crypto_refs or []
 
     @property
+    @serializable.type_mapping(_ProtocolPropertiesTypeSerializationHelper)
     @serializable.xml_sequence(10)
     def type(self) -> Optional[ProtocolPropertiesType]:
         """


### PR DESCRIPTION


### Description

Added the enum cases for `ProtocolPropertiesType` related to CycloneDX 1.7

Resolves or fixes issue: <!-- ✍️ Add GitHub issue number in format `#0000` - if there is none fitting, create one -->

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CONTRIBUTING.md) guidelines
