### PR TITLE
fix: ProtocolPropertiesType enum case `5g-aka` for CycloneDX 1.7

### DIFF
--- a/cyclonedx/model/crypto.py
+++ b/cyclonedx/model/crypto.py
@@ -1185,6 +1185,7 @@ class _ProtocolPropertiesTypeSerializationHelper(serializable.helpers.BaseHelper
         ProtocolPropertiesType.DTLS,
         ProtocolPropertiesType.EAP_AKA,
         ProtocolPropertiesType.EAP_AKA_PRIME,
+        ProtocolPropertiesType.FIVEG_AKA,
         ProtocolPropertiesType.PRINS,
         ProtocolPropertiesType.QUIC,
     }


### PR DESCRIPTION


### Description

fixed `ProtocolPropertiesType` enum case `5g-aka` for CycloneDX 1.7

Resolves or fixes issue: <!-- ✍️ Add GitHub issue number in format `#0000` - if there is none fitting, create one -->

### AI Tool Disclosure

- [x] My contribution does not include any AI-generated content
- [ ] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `[e.g. GitHub CoPilot, ChatGPT, JetBrains Junie etc.]`
  - LLMs and versions: `[e.g. GPT-4.1, Claude Haiku 4.5, Gemini 2.5 Pro etc.]`
  - Prompts: `[Summarize the key prompts or instructions given to the AI tools]`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CONTRIBUTING.md) guidelines
