### PR TITLE
fix: ComparablePackageURL includes `name`

### DIFF
--- a/cyclonedx/_internal/compare.py
+++ b/cyclonedx/_internal/compare.py
@@ -76,6 +76,7 @@ class ComparablePackageURL(ComparableTuple):
         return super().__new__(cls, (
             p.type,
             p.namespace,
+            p.name,
             p.version,
             ComparableDict(p.qualifiers) if isinstance(p.qualifiers, dict) else p.qualifiers,
             p.subpath

--- a/tests/test_internal/test_compare.py
+++ b/tests/test_internal/test_compare.py
@@ -1,0 +1,43 @@
+# This file is part of CycloneDX Python Library
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) OWASP Foundation. All Rights Reserved.
+
+from unittest import TestCase
+
+from packageurl import PackageURL
+
+from cyclonedx._internal.compare import ComparablePackageURL
+
+
+class TestComparablePackageURL(TestCase):
+
+    def test_differs_by_name(self) -> None:
+        """
+        regression for https://github.com/CycloneDX/cyclonedx-python-lib/issues/1021
+
+        name was missing from the comparison tuple, so two purls that differ
+        only by name compared equal
+        """
+        purl1 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
+        purl2 = ComparablePackageURL(PackageURL(type='pypi', name='bar', version='1.0.0'))
+        self.assertNotEqual(purl1, purl2)
+        self.assertGreater(purl1, purl2)
+        self.assertLess(purl2, purl1)
+
+    def test_equal_same_purl(self) -> None:
+        purl1 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
+        purl2 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
+        self.assertEqual(purl1, purl2)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -23,9 +23,7 @@ from uuid import UUID
 
 from ddt import ddt, named_data
 
-from packageurl import PackageURL
-
-from cyclonedx._internal.compare import ComparablePackageURL, ComparableTuple
+from cyclonedx._internal.compare import ComparableTuple
 from cyclonedx.exception.model import InvalidLocaleTypeException, InvalidUriException, UnknownHashTypeException
 from cyclonedx.model import (
     Copyright,
@@ -70,23 +68,6 @@ class TestStringEnum(TestCase):
             DummyStringEnum.THIRD,
         ]
         self.assertListEqual(sorted_enums, expected_enums)
-
-
-class TestComparablePackageURL(TestCase):
-
-    def test_differs_by_name(self) -> None:
-        # name was missing from the comparison tuple, so two purls that differ
-        # only by name compared equal
-        purl1 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
-        purl2 = ComparablePackageURL(PackageURL(type='pypi', name='bar', version='1.0.0'))
-        self.assertNotEqual(purl1, purl2)
-        self.assertGreater(purl1, purl2)
-        self.assertLess(purl2, purl1)
-
-    def test_equal_same_purl(self) -> None:
-        purl1 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
-        purl2 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
-        self.assertEqual(purl1, purl2)
 
 
 class TestComparableTuple(TestCase):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -23,7 +23,9 @@ from uuid import UUID
 
 from ddt import ddt, named_data
 
-from cyclonedx._internal.compare import ComparableTuple
+from packageurl import PackageURL
+
+from cyclonedx._internal.compare import ComparablePackageURL, ComparableTuple
 from cyclonedx.exception.model import InvalidLocaleTypeException, InvalidUriException, UnknownHashTypeException
 from cyclonedx.model import (
     Copyright,
@@ -68,6 +70,23 @@ class TestStringEnum(TestCase):
             DummyStringEnum.THIRD,
         ]
         self.assertListEqual(sorted_enums, expected_enums)
+
+
+class TestComparablePackageURL(TestCase):
+
+    def test_differs_by_name(self) -> None:
+        # name was missing from the comparison tuple, so two purls that differ
+        # only by name compared equal
+        purl1 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
+        purl2 = ComparablePackageURL(PackageURL(type='pypi', name='bar', version='1.0.0'))
+        self.assertNotEqual(purl1, purl2)
+        self.assertGreater(purl1, purl2)
+        self.assertLess(purl2, purl1)
+
+    def test_equal_same_purl(self) -> None:
+        purl1 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
+        purl2 = ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0'))
+        self.assertEqual(purl1, purl2)
 
 
 class TestComparableTuple(TestCase):


### PR DESCRIPTION
### Description

`ComparablePackageURL` built its comparison tuple from type, namespace, version, qualifiers and subpath, leaving out `name`. Two different packages therefore compared equal whenever everything else matched:

```python
>>> ComparablePackageURL(PackageURL(type='pypi', name='foo', version='1.0.0')) \
...     == ComparablePackageURL(PackageURL(type='pypi', name='bar', version='1.0.0'))
True
```

Both collapse to `('pypi', None, '1.0.0', (), None)`. Since `name` is a required purl component and the main thing distinguishing one package from another, anything sorting components by purl treated unrelated packages as interchangeable, with their relative order left to the sort.

This adds `p.name` in its canonical position, between namespace and version.

Resolves or fixes issue: #1021

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `Claude Code`
  - LLMs and versions: `Claude Opus 5`
  - Prompts: `Asked it to read cyclonedx/_internal/compare.py and check the comparison tuples against the purl spec, then to draft a regression test in the style of the existing TestComparableTuple cases. I reviewed and ran everything myself.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CONTRIBUTING.md) guidelines

### Tests

`TestComparablePackageURL.test_differs_by_name` fails on main, with the assertion showing the two identical tuples, and passes with the change. A second case pins that identical purls still compare equal. Full suite is 6961 tests, OK.
