### PR TITLE
fix: encode paths when loading XML schemas

### DIFF
--- a/cyclonedx/validation/xml.py
+++ b/cyclonedx/validation/xml.py
@@ -20,6 +20,7 @@ __all__ = ['XmlValidator', 'XmlValidationError']
 
 from abc import ABC
 from collections.abc import Iterable
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, Optional, Union, overload
 
 from ..exception import MissingOptionalDependencyException
@@ -125,7 +126,7 @@ class _BaseXmlValidator(BaseSchemabasedValidator, ABC):
                 schema_file = self._schema_file
                 if schema_file is None:
                     raise NotImplementedError('missing schema file')
-                self.__validator = XMLSchema(file=schema_file)
+                self.__validator = XMLSchema(file=Path(schema_file).absolute().as_uri())
             return self.__validator
 
 

--- a/tests/test_validation_xml.py
+++ b/tests/test_validation_xml.py
@@ -18,13 +18,17 @@
 from collections.abc import Generator
 from glob import iglob
 from itertools import chain
-from os.path import join
+from os.path import basename, dirname, join
+from shutil import copytree
+from tempfile import TemporaryDirectory
 from unittest import TestCase
+from unittest.mock import patch
 
 from ddt import ddt, idata, unpack
 
 from cyclonedx.exception import MissingOptionalDependencyException
 from cyclonedx.schema import OutputFormat, SchemaVersion
+from cyclonedx.schema._res import BOM_XML
 from cyclonedx.validation.xml import XmlValidator
 from tests import OWN_DATA_DIRECTORY, SCHEMA_TESTDATA_DIRECTORY, DpTuple
 
@@ -50,6 +54,23 @@ def _dp_sv_own(valid: bool) -> Generator:
 
 @ddt
 class TestXmlValidator(TestCase):
+
+    def test_validate_schema_from_path_with_fragment_character(self) -> None:
+        schema_version = SchemaVersion.V1_6
+        schema_file = BOM_XML[schema_version]
+        self.assertIsNotNone(schema_file)
+
+        with TemporaryDirectory(prefix='cyclonedx#') as temp_directory:
+            schema_directory = join(temp_directory, 'schemas')
+            copytree(dirname(schema_file), schema_directory)
+            copied_schema_file = join(schema_directory, basename(schema_file))
+
+            with patch.dict('cyclonedx.validation.xml._S_BOM', {schema_version: copied_schema_file}):
+                validation_error = XmlValidator(schema_version).validate_str(
+                    '<bom xmlns="http://cyclonedx.org/schema/bom/1.6" version="1"/>'
+                )
+
+        self.assertIsNone(validation_error)
 
     @idata(sv for sv in SchemaVersion if sv not in UNSUPPORTED_SCHEMA_VERSIONS)
     def test_validator_as_expected(self, schema_version: SchemaVersion) -> None:


### PR DESCRIPTION
### Description

`lxml` 5.x treats the path passed to `XMLSchema(file=...)` as a URL. When the local package path contains `#`, the fragment handling changes the base URL and the relative `spdx.SNAPSHOT.xsd` import is not resolved.

This change converts the absolute local schema path to an encoded `file:` URI before loading it. It also adds a regression test that copies the bundled schemas beneath a path containing `#` and validates a minimal CycloneDX 1.6 document.

Resolves or fixes issue: #551

### Validation

- Regression test reproduced the `XMLSchemaParseError` with lxml 5.3.2/libxml2 2.12.10 before the fix and passes after it.
- The same test passes with lxml 4.9.4, 5.3.2, and 6.1.1 on Windows or WSL as available.
- Full suite: 6,962 tests passed on Python 3.13.
- `poetry run tox run -e py313-allExtras,py313-noExtras,flake8,mypy-current,mypy-lowest,bandit,deptry`
- `poetry build` produced both wheel and sdist.
- The built wheel was installed into a clean WSL environment whose site-packages path contains `#`; generated CycloneDX 1.6 XML passed `XmlValidator` with lxml 5.3.2.

### AI Tool Disclosure

- [ ] My contribution does not include any AI-generated content
- [x] My contribution includes AI-generated content, as disclosed below:
  - AI Tools: `OpenAI Codex`
  - LLMs and versions: `GPT-5`
  - Prompts: `Research maintainer-confirmed issue #551, reproduce it with supported lxml versions, implement the smallest local-file URI compatibility fix, add a regression test, and run the repository's complete checks and package smoke test.`

### Affirmation

- [x] My code follows the [CONTRIBUTING.md](https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CONTRIBUTING.md) guidelines
