### PR TITLE
tests: add Python 3.14 to tox tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ minversion = 4.0
 envlist =
     flake8
     mypy-{current,lowest}
-    py{313,312,311,310,39}-{allExtras,noExtras}
+    py{314,313,312,311,310,39}-{allExtras,noExtras}
     bandit
     deptry
 skip_missing_interpreters = True


### PR DESCRIPTION
python 3.14 was in GH workflow tests, already. 